### PR TITLE
remove `attn_bias` and `attn_bias_self_attention` param

### DIFF
--- a/sam3/model/decoder.py
+++ b/sam3/model/decoder.py
@@ -775,7 +775,6 @@ class TransformerDecoderLayerv1(nn.Module):
         memory_key_padding_mask: Optional[Tensor] = None,
         pos: Optional[Tensor] = None,
         query_pos: Optional[Tensor] = None,
-        attn_bias_self_attention: Optional[Tensor] = None,
         **kwargs,
     ):
         q = k = tgt + query_pos if self.pos_enc_at_attn else tgt
@@ -787,7 +786,6 @@ class TransformerDecoderLayerv1(nn.Module):
             value=tgt,
             attn_mask=tgt_mask,
             key_padding_mask=tgt_key_padding_mask,
-            attn_bias=attn_bias_self_attention,
         )[0]
         tgt = tgt + self.dropout1(tgt2)
         tgt = self.norm1(tgt)
@@ -821,7 +819,6 @@ class TransformerDecoderLayerv1(nn.Module):
         pos: Optional[Tensor] = None,
         query_pos: Optional[Tensor] = None,
         attn_bias: Optional[Tensor] = None,
-        attn_bias_self_attention: Optional[Tensor] = None,
         **kwargs,
     ):
         if dac:
@@ -837,7 +834,6 @@ class TransformerDecoderLayerv1(nn.Module):
             value=tgt2,
             attn_mask=tgt_mask,
             key_padding_mask=tgt_key_padding_mask,
-            attn_bias=attn_bias_self_attention,
         )[0]
         tgt = tgt + self.dropout1(tgt2)
         if dac:
@@ -870,7 +866,6 @@ class TransformerDecoderLayerv1(nn.Module):
         pos: Optional[Tensor] = None,
         query_pos: Optional[Tensor] = None,
         attn_bias: Optional[Tensor] = None,
-        attn_bias_self_attention: Optional[Tensor] = None,
         **kwds: Any,
     ) -> torch.Tensor:
         fwd_fn = self.forward_pre if self.pre_norm else self.forward_post
@@ -885,7 +880,6 @@ class TransformerDecoderLayerv1(nn.Module):
             pos=pos,
             query_pos=query_pos,
             attn_bias=attn_bias,
-            attn_bias_self_attention=attn_bias_self_attention,
             **kwds,
         )
 

--- a/sam3/model/encoder.py
+++ b/sam3/model/encoder.py
@@ -48,7 +48,6 @@ class TransformerEncoderLayerSimple(nn.Module):
         src_mask: Optional[Tensor] = None,
         src_key_padding_mask: Optional[Tensor] = None,
         pos: Optional[Tensor] = None,
-        attn_bias_self_attention: Optional[Tensor] = None,
     ):
         q = k = self.with_pos_embed(src, pos)
         src2 = self.self_attn(
@@ -57,7 +56,6 @@ class TransformerEncoderLayerSimple(nn.Module):
             value=src,
             attn_mask=src_mask,
             key_padding_mask=src_key_padding_mask,
-            attn_bias=attn_bias_self_attention,
         )[0]
         src = src + self.dropout1(src2)
         src = self.norm1(src)
@@ -72,7 +70,6 @@ class TransformerEncoderLayerSimple(nn.Module):
         src_mask: Optional[Tensor] = None,
         src_key_padding_mask: Optional[Tensor] = None,
         pos: Optional[Tensor] = None,
-        attn_bias_self_attention: Optional[Tensor] = None,
     ):
         src2 = self.norm1(src)
         q = k = self.with_pos_embed(src2, pos)
@@ -82,7 +79,6 @@ class TransformerEncoderLayerSimple(nn.Module):
             value=src2,
             attn_mask=src_mask,
             key_padding_mask=src_key_padding_mask,
-            attn_bias=attn_bias_self_attention,
         )[0]
         src = src + self.dropout1(src2)
         src2 = self.norm2(src)
@@ -96,7 +92,6 @@ class TransformerEncoderLayerSimple(nn.Module):
         src_mask: Optional[Tensor] = None,
         src_key_padding_mask: Optional[Tensor] = None,
         pos: Optional[Tensor] = None,
-        attn_bias_self_attention: Optional[Tensor] = None,
         **kwargs,
     ):
         if self.pre_norm:
@@ -105,14 +100,12 @@ class TransformerEncoderLayerSimple(nn.Module):
                 src_mask,
                 src_key_padding_mask,
                 pos,
-                attn_bias_self_attention=attn_bias_self_attention,
             )
         return self.forward_post(
             src,
             src_mask,
             src_key_padding_mask,
             pos,
-            attn_bias_self_attention=attn_bias_self_attention,
         )
 
 


### PR DESCRIPTION
The `attn_bias_self_attention` param is currently causing an error, since now our `self_attn` module is purely using the [`nn.MultiheadAttention`](https://docs.pytorch.org/docs/stable/generated/torch.nn.MultiheadAttention.html) class that doesn't have this `attn_bias` param.

In this small PR, we remove `attn_bias` and `attn_bias_self_attention` param as they are not used anywhere in the model and it is not compatible with `nn.MultiheadAttention`.