### PR TITLE
nits: potentially load "model" in ckpt files; add `*-Copy*.ipynb` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,7 @@ target/
 
 # Jupyter Notebook
 .ipynb_checkpoints
+*-Copy*.ipynb
 
 # IPython
 profile_default/

--- a/sam3/model_builder.py
+++ b/sam3/model_builder.py
@@ -360,6 +360,8 @@ def build_sam3_image_model(
     # move to eval mode
     if checkpoint_path is not None:
         ckpt = torch.load(checkpoint_path, map_location="cpu", weights_only=True)
+        if "model" in ckpt and isinstance(ckpt["model"], dict):
+            ckpt = ckpt["model"]
         missing_keys, unexpected_keys = model.load_state_dict(ckpt, strict=False)
         if len(missing_keys) > 0 or len(unexpected_keys) > 0:
             print(

--- a/sam3/sam3_dense_tracking_builder.py
+++ b/sam3/sam3_dense_tracking_builder.py
@@ -560,6 +560,8 @@ def build_sam3_dense_tracking_model(
     # Load checkpoint if provided
     if checkpoint_path is not None:
         ckpt = torch.load(checkpoint_path, map_location="cpu", weights_only=True)
+        if "model" in ckpt and isinstance(ckpt["model"], dict):
+            ckpt = ckpt["model"]
         missing_keys, unexpected_keys = model.load_state_dict(ckpt, strict=False)
         if missing_keys:
             print(f"Missing keys: {missing_keys}")


### PR DESCRIPTION
In this mini PR, we also allow handling checkpoints where the state dict is under the "model" key. This simplifies the procedure for testing new checkpoints that contains this "model" key.

Also, we should consider canonicalizing all checkpoints to put their model state dict under the "model" dict, similar to SAM2 (https://github.com/facebookresearch/sam2/blob/2b90b9f5ceec907a1c18123530e92e794ad901a4/sam2/build_sam.py#L166)