### PR TITLE
[video cleanup] clean up single-GPU and multi-GPU prediction wrapper and reorganize class structures

### DIFF
--- a/examples/sam3_dense_video_tracking.ipynb
+++ b/examples/sam3_dense_video_tracking.ipynb
@@ -46,18 +46,17 @@
    "outputs": [],
    "source": [
     "import os\n",
-    "from glob import glob\n",
-    "from sam3.model.sam3_model_web import Sam3Model\n",
-    "from sam3.model.sam3_model_web_multigpu import Sam3ModelMultiGPU\n",
+    "from sam3.model.sam3_video_predictor_multigpu import Sam3VideoPredictorMultiGPU\n",
     "\n",
+    "\n",
+    "# to use a single GPU, set GPUS_TO_USE = [0]\n",
     "GPUS_TO_USE = [0, 1, 2, 3, 4, 5, 6, 7]\n",
-    "# set the GPUs to use via \"CUDA_VISIBLE_DEVICES\"\n",
     "assert all(isinstance(i, int) for i in GPUS_TO_USE)\n",
     "assert GPUS_TO_USE == sorted(set(GPUS_TO_USE))\n",
     "os.environ[\"CUDA_VISIBLE_DEVICES\"] = \",\".join(str(i) for i in GPUS_TO_USE)\n",
     "\n",
     "\n",
-    "model_wrapper = Sam3ModelMultiGPU( # use Sam3Model for running on single GPU\n",
+    "model_wrapper = Sam3VideoPredictorMultiGPU(\n",
     "    bpe_path=bpe_path,\n",
     "    checkpoint_path=checkpoint_file,\n",
     "    has_presence_token=has_presence_token,\n",
@@ -84,8 +83,8 @@
    },
    "outputs": [],
    "source": [
+    "import glob\n",
     "import matplotlib.pyplot as plt\n",
-    "\n",
     "from utils import visualize_formatted_frame_output, prepare_masks_for_visualization"
    ]
   },
@@ -112,6 +111,26 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# load \"image_files\" for visualization purposes (they are not used by the model)\n",
+    "image_files = glob.glob(os.path.join(video_frames_dir, \"*.jpg\"))\n",
+    "try:\n",
+    "    # integer sort instead of string sort (so that e.g. \"2.jpg\" is before \"11.jpg\")\n",
+    "    image_files.sort(key=lambda p: int(os.path.splitext(os.path.basename(p))[0]))\n",
+    "except ValueError:\n",
+    "    # fallback to lexicographic sort if the format is not \"<frame_index>.jpg\"\n",
+    "    print(\n",
+    "        f'frame names are not in \"<frame_index>.jpg\" format: {image_files[:5]=}, '\n",
+    "        f\"falling back to lexicographic sort.\"\n",
+    "    )\n",
+    "    image_files.sort()"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -135,20 +154,7 @@
     "        resource_path=video_frames_dir,\n",
     "    )\n",
     ")\n",
-    "session_id = response[\"session_id\"]\n",
-    "\n",
-    "# \"image_files\" is only needed for visualization purposes (not used by the model)\n",
-    "image_files = glob(os.path.join(video_frames_dir, \"*.jpg\"))\n",
-    "try:\n",
-    "    # integer sort instead of string sort (so that e.g. \"2.jpg\" is before \"11.jpg\")\n",
-    "    image_files.sort(key=lambda p: int(os.path.splitext(os.path.basename(p))[0]))\n",
-    "except ValueError:\n",
-    "    # fallback to lexicographic sort if the format is not \"<frame_index>.jpg\"\n",
-    "    print(\n",
-    "        f'frame names are not in \"<frame_index>.jpg\" format: {image_files[:5]=}, '\n",
-    "        f\"falling back to lexicographic sort.\"\n",
-    "    )\n",
-    "    image_files.sort()"
+    "session_id = response[\"session_id\"]"
    ]
   },
   {
@@ -245,6 +251,7 @@
     "    )\n",
     "):\n",
     "    outputs_per_frame[response[\"frame_index\"]] = response[\"outputs\"]\n",
+    "\n",
     "outputs_per_frame = prepare_masks_for_visualization(outputs_per_frame)"
    ]
   },

--- a/sam3/model/sam3_video_base.py
+++ b/sam3/model/sam3_video_base.py
@@ -21,7 +21,6 @@ from sam3.logger import get_logger
 from sam3.model.data_misc import BatchedDatapoint
 from sam3.model.model_misc import NestedTensor
 from sam3.model.nms_utils import mask_iou
-from sam3.model.sam3_image import Sam3ImageOnVideoMultiGPU
 from sam3.model.video_tracking_with_prompt_utils import (
     fill_holes_in_mask_scores,
     mask_to_box,
@@ -200,7 +199,7 @@ class Sam2Predictor(nn.Module):
 #         self._add_output_per_object(*args, **kwargs)
 
 
-class Sam3DenseTrackingMultiGPU(nn.Module):
+class Sam3VideoBase(nn.Module):
     def __init__(
         self,
         sam2_model,

--- a/sam3/model/sam3_video_inference.py
+++ b/sam3/model/sam3_video_inference.py
@@ -3,17 +3,16 @@
 import gc
 import logging
 from collections import defaultdict
-from functools import reduce
 
 import numpy as np
-
 import torch
 import torch.distributed as dist
 import torch.nn.functional as F
 from torchvision.ops import masks_to_boxes
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 from sam3 import perflib
+from sam3.logger import get_logger
 from sam3.model.act_ckpt_utils import clone_output_wrapper
 from sam3.model.box_ops import box_xywh_to_cxcywh, box_xyxy_to_xywh
 from sam3.model.data_misc import (
@@ -26,13 +25,7 @@ from sam3.model.data_misc import (
 from sam3.model.geometry_encoders import Prompt
 from sam3.model.model_misc import NestedTensor
 from sam3.model.nms_utils import mask_iou
-
-from sam3.model.sam3_video_base import (
-    MaskletConfirmationStatus,
-    Sam3DenseTrackingMultiGPU,
-)
-
-# Sam3DemoMixin functionality - using sam3 imports
+from sam3.model.sam3_video_base import MaskletConfirmationStatus, Sam3VideoBase
 from sam3.model.video_tracking_with_prompt_utils import (
     fill_holes_in_mask_scores,
     load_resource_as_video_frames,
@@ -40,16 +33,13 @@ from sam3.model.video_tracking_with_prompt_utils import (
 from sam3.perflib.compile import compile_wrapper, shape_logging_wrapper
 from sam3.perflib.masks_to_boxes import masks_to_boxes as perf_masks_to_boxes
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
-class Sam3DemoMixin:
+class Sam3VideoInferenceMixin:
     TEXT_ID_FOR_TEXT = 0
     TEXT_ID_FOR_VISUAL = 1
     TEXT_ID_FOR_GEOMETRIC = 2
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
 
     @torch.inference_mode()
     def init_state(
@@ -224,7 +214,7 @@ class Sam3DemoMixin:
         return boxes_cxcywh, box_labels, new_visual_prompt
 
 
-class Sam3DenseTrackingDemoMultiGPU(Sam3DemoMixin, Sam3DenseTrackingMultiGPU):
+class Sam3VideoInferenceMultiGPU(Sam3VideoInferenceMixin, Sam3VideoBase):
     def __init__(
         self,
         image_size=1008,
@@ -388,7 +378,7 @@ class Sam3DenseTrackingDemoMultiGPU(Sam3DemoMixin, Sam3DenseTrackingMultiGPU):
             for yield_frame_idx, yield_out in yield_list:
                 # post-process the output and yield it
                 with torch.profiler.record_function(
-                    "Sam3DenseTrackingDemoMultiGPU.postprocess_output"
+                    "Sam3VideoInferenceMultiGPU.postprocess_output"
                 ):
                     if self.rank == 0:
                         suppressed_obj_ids = yield_out["suppressed_obj_ids"]
@@ -929,8 +919,6 @@ class Sam3DenseTrackingDemoMultiGPU(Sam3DemoMixin, Sam3DenseTrackingMultiGPU):
 
         Note that text prompts are NOT associated with a particular frame (i.e. they apply
         to all frames). However, we only run inference on the frame specified in `frame_idx`.
-
-        Copied from sam3_demo.Sam3DemoMixin.add_prompt, simplified to support only text prompts.
         """
         logger.info("Running add_prompt on frame %d", frame_idx)
 
@@ -1059,9 +1047,7 @@ class Sam3DenseTrackingDemoMultiGPU(Sam3DemoMixin, Sam3DenseTrackingMultiGPU):
         return {video_id: preds}
 
 
-class Sam3DenseTrackingDemoMultiGPUWithInstanceInteractivity(
-    Sam3DenseTrackingDemoMultiGPU
-):
+class Sam3VideoInferenceMultiGPUWithInstanceInteractivity(Sam3VideoInferenceMultiGPU):
     def __init__(
         self,
         use_prev_mem_frame=False,

--- a/sam3/model/sam3_video_predictor.py
+++ b/sam3/model/sam3_video_predictor.py
@@ -1,7 +1,6 @@
 # Copyright (c) Meta, Inc. and its affiliates. All Rights Reserved
 
 import gc
-import threading
 import time
 import uuid
 from typing import List, Optional
@@ -14,20 +13,17 @@ from sam3.sam3_dense_tracking_builder import build_sam3_dense_tracking_model
 logger = get_logger(__name__)
 
 
-class Sam3Model:
+class Sam3VideoPredictor:
     def __init__(
         self,
         bpe_path,
         checkpoint_path,
         has_presence_token=False,
         geo_encoder_use_img_cross_attn=False,
-        session_expiration_sec=1200,  # the time (sec) for a session to expire after no activities
         strict_state_dict_loading=True,
         default_output_prob_thresh=0.5,
         async_loading_frames=True,
     ):
-
-        self.session_expiration_sec = session_expiration_sec
         self.default_output_prob_thresh = default_output_prob_thresh
         self.async_loading_frames = async_loading_frames
 
@@ -69,8 +65,6 @@ class Sam3Model:
             )
         elif request_type == "reset_session":
             return self.reset_session(session_id=request["session_id"])
-        elif request_type == "renew_session":
-            return self.renew_session(session_id=request["session_id"])
         elif request_type == "close_session":
             return self.close_session(session_id=request["session_id"])
         else:
@@ -111,12 +105,8 @@ class Sam3Model:
             session_id = str(uuid.uuid4())
         _ALL_INFERENCE_STATES[session_id] = {
             "state": inference_state,
-            "last_use_time": time.time(),
-            "expiration_sec": self.session_expiration_sec,
             "session_id": session_id,
             "start_time": time.time(),
-            # "config_file": self.config_file,
-            # "checkpoint_file": self.checkpoint_file,
         }
         logger.info(
             f"started new session {session_id}; {_get_session_stats()}; "
@@ -145,7 +135,6 @@ class Sam3Model:
         )
         session = _get_session(session_id)
         inference_state = session["state"]
-        _extend_expiration_time(session)
 
         frame_idx, outputs = self.model.add_prompt(
             inference_state=inference_state,
@@ -180,7 +169,6 @@ class Sam3Model:
         try:
             session = _get_session(session_id)
             inference_state = session["state"]
-            _extend_expiration_time(session)
             if propagation_direction not in ["both", "forward", "backward"]:
                 raise ValueError(
                     f"invalid propagation direction: {propagation_direction}"
@@ -218,15 +206,7 @@ class Sam3Model:
         logger.info(f"clear all inputs across the video in session {session_id}")
         session = _get_session(session_id)
         inference_state = session["state"]
-        _extend_expiration_time(session)
         self.model.reset_state(inference_state)
-        return {"is_success": True}
-
-    def renew_session(self, session_id):
-        """Renew a session (to update its last usage time and reset its expiration timer)."""
-        logger.info(f"renew session {session_id}")
-        session = _get_session(session_id)
-        _extend_expiration_time(session)
         return {"is_success": True}
 
     def close_session(self, session_id):
@@ -252,29 +232,6 @@ def _get_session(session_id):
     if session is None:
         raise RuntimeError(f"Cannot find session {session_id}; it might have expired")
     return session
-
-
-def _extend_expiration_time(session):
-    """Extend the expiration time of a session."""
-    session["last_use_time"] = time.time()
-
-
-def _cleanup_expired_sessions():
-    """Clean up expired sessions that haven't been used in a while."""
-    while True:
-        try:
-            current_time = time.time()
-            for session_id, session in list(_ALL_INFERENCE_STATES.items()):
-                if current_time - session["last_use_time"] > session["expiration_sec"]:
-                    # close the expired session
-                    _ALL_INFERENCE_STATES.pop(session_id, None)
-                    gc.collect()
-                    logger.info(
-                        f"removed expired session {session_id}; {_get_session_stats()}"
-                    )
-        except Exception:
-            pass  # catch and ignore any errors (just to be prudent)
-        time.sleep(30)  # clean up every 30 sec
 
 
 def _get_session_stats():
@@ -305,5 +262,3 @@ def _get_torch_and_gpu_properties():
 
 # a global dictionary that holds all inference states for this model (key is session_id)
 _ALL_INFERENCE_STATES = {}
-# a daemon thread to clean up expired session
-threading.Thread(target=_cleanup_expired_sessions, daemon=True).start()

--- a/sam3/sam3_dense_tracking_builder.py
+++ b/sam3/sam3_dense_tracking_builder.py
@@ -36,7 +36,7 @@ from sam3.model.model_misc import DotProductScoring, MLP, TransformerWrapper
 from sam3.model.necks import Sam3DualViTDetNeck
 from sam3.model.position_encoding import PositionEmbeddingSine
 from sam3.model.sam3_image import Sam3ImageOnVideoMultiGPU
-from sam3.model.sam3_video_inference import Sam3DenseTrackingDemoMultiGPU
+from sam3.model.sam3_video_inference import Sam3VideoInferenceMultiGPU
 from sam3.model.text_encoder_ve import VETextEncoder
 from sam3.model.tokenizer_ve import SimpleTokenizer
 from sam3.model.video_tracking_with_prompt_demo import Sam3TrackerPredictor
@@ -479,7 +479,7 @@ def build_sam3_dense_tracking_model(
     has_presence_token: bool = False,
     geo_encoder_use_img_cross_attn: bool = False,
     strict_state_dict_loading: bool = True,
-) -> Sam3DenseTrackingDemoMultiGPU:
+) -> Sam3VideoInferenceMultiGPU:
     """
     Build SAM3 dense tracking model.
 
@@ -488,7 +488,7 @@ def build_sam3_dense_tracking_model(
         checkpoint_path: Optional path to checkpoint file
 
     Returns:
-        Sam3DenseTrackingDemoMultiGPU: The instantiated dense tracking model
+        Sam3VideoInferenceMultiGPU: The instantiated dense tracking model
     """
     # Build SAM2 model
     sam2_model = build_sam2_model()
@@ -533,7 +533,7 @@ def build_sam3_dense_tracking_model(
     )
 
     # Create the main dense tracking model
-    model = Sam3DenseTrackingDemoMultiGPU(
+    model = Sam3VideoInferenceMultiGPU(
         sam2_model=sam2_model,
         sam3_model=sam3_model,
         ckpt_path=None,


### PR DESCRIPTION
(this PR a piece in the [video predictor refactoring stack](https://github.com/facebookresearch/sam3/pulls?q=is%3Apr+label%3Avideo_predictor))

This small PR is one of the intermediate steps on video cleanup -- we clean up single-GPU and multi-GPU prediction wrapper and reorganize the class structures. Specifically, we remove the components no longer needed for the predictions, such as automatic session expiration (that we inherited from the webdemo class).