### PR TITLE
[video cleanup] minor: patch inference api around `sam3_v2_rc1`

### DIFF
--- a/examples/sam3_video_predictor_example.ipynb
+++ b/examples/sam3_video_predictor_example.ipynb
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -27,8 +27,13 @@
     "# has_presence_token = False\n",
     "# geo_encoder_use_img_cross_attn = False\n",
     "\n",
-    "# prod v14 model (s3://fb-fair-onevision/ronghanghu/sam3_release/ckpts/sam3_v14_rc1.pt)\n",
-    "checkpoint_file = \"/checkpoint/sam3/ronghanghu/sam3_release/ckpts/sam3_v14_rc1.pt\"\n",
+    "# # prod v14 model (s3://fb-fair-onevision/ronghanghu/sam3_release/ckpts/sam3_v14_rc1.pt)\n",
+    "# checkpoint_file = \"/checkpoint/sam3/ronghanghu/sam3_release/ckpts/sam3_v14_rc1.pt\"\n",
+    "# has_presence_token = True\n",
+    "# geo_encoder_use_img_cross_attn = True\n",
+    "\n",
+    "# sam3_v2_rc1 model (s3://fb-fair-onevision/haithamkhedr/checkpoints/sam3_v2_rc1/sam3_v2_rc1.pt)\n",
+    "checkpoint_file = \"/checkpoint/sam3/haithamkhedr/checkpoints/sam3_dense/sam3_v2_rc1.pt\"\n",
     "has_presence_token = True\n",
     "geo_encoder_use_img_cross_attn = True"
    ]

--- a/sam3/model/sam3_video_inference.py
+++ b/sam3/model/sam3_video_inference.py
@@ -141,9 +141,6 @@ class Sam3VideoInference(Sam3VideoBase):
         # 3) find_inputs
         input_box_embedding_dim = 258  # historical default
         input_points_embedding_dim = 257  # historical default
-        dummy_ptrs = BatchedPointer(
-            stage_ids=[], query_ids=[], object_ids=[], ptr_mask=[], ptr_types=[]
-        )
         stages = [
             FindStage(
                 img_ids=[stage_id],
@@ -155,8 +152,6 @@ class Sam3VideoInference(Sam3VideoBase):
                 input_points=[torch.empty(0, input_points_embedding_dim)],
                 input_points_before_embed=[torch.empty(0, 3)],
                 input_points_mask=[torch.empty(0)],
-                ptrs=dummy_ptrs,
-                ptrs_seg=dummy_ptrs,
                 object_ids=[],
             )
             for stage_id in range(num_frames)
@@ -170,7 +165,6 @@ class Sam3VideoInference(Sam3VideoBase):
             find_text_batch=find_text_batch,
             find_inputs=stages,
             find_targets=[None] * num_frames,
-            get_queries=None,
             find_metadatas=[None] * num_frames,
         )
         input_batch = recursive_to(input_batch, device, non_blocking=True)


### PR DESCRIPTION
(this PR a piece in the [video predictor refactoring stack](https://github.com/facebookresearch/sam3/pulls?q=is%3Apr+label%3Avideo_predictor))

In this small PR, we update video inference API to be compatible with the latest `FindStage` and `BatchedDatapoint` format, and also add sam3_v2_rc1 ckpt.