### PR TITLE
fixup: directly fold presence logits into the model's logits predictions in the video predictor

### DIFF
--- a/sam3/model/sam3_video_base.py
+++ b/sam3/model/sam3_video_base.py
@@ -14,6 +14,7 @@ import numpy.typing as npt
 import torch
 import torch.distributed as dist
 import torch.nn.functional as F
+from torch import nn, Tensor
 
 from sam3 import perflib
 from sam3.logger import get_logger
@@ -21,7 +22,6 @@ from sam3.model.data_misc import BatchedDatapoint
 from sam3.model.nms_utils import mask_iou
 from sam3.model.sam3_tracker_utils import fill_holes_in_mask_scores, mask_to_box
 from sam3.train.masks_ops import rle_encode
-from torch import nn, Tensor
 
 logger = get_logger(__name__)
 

--- a/sam3/sam3_video_model_builder.py
+++ b/sam3/sam3_video_model_builder.py
@@ -566,6 +566,7 @@ def build_sam3_video_model(
         use_early_fusion=True,
         use_dot_prod_scoring=True,
         dot_prod_scoring=main_dot_prod_scoring,
+        supervise_joint_box_scores=has_presence_token,
     )
 
     # Build the main SAM3 video model

--- a/sam3/train/train.py
+++ b/sam3/train/train.py
@@ -311,7 +311,7 @@ def main(args) -> None:
 
 if __name__ == "__main__":
 
-    initialize_config_module("train", version_base="1.2")
+    initialize_config_module("sam3.train", version_base="1.2")
     parser = ArgumentParser()
     parser.add_argument(
         "-c",


### PR DESCRIPTION
In this PR, we fix an inference error in the current video model with presence scores. Unlike the image grounding model where the presence score is handled in as a part of the post processing, in the video model, the presence score needs to be in the detection logits since it would be consumed by other parts of the model.

We also update eval parameters following https://github.com/fairinternal/onevision/blob/c5fecef6900b3000a28aeaf000b066b86c11a46e/projects/onevision/config/experiments/haithamkhedr/sam3_dense/ablations/sam3_v14_rc1_eval_sac_sstk.multigpu_ablation_hot_supp_recon16.yaml#L337-L354

Thanks to @kalyanvasudev and @haithamkhedr for the detailed investigation into this!