### PR TITLE
fall back to `timm.models.layers` for compatibility for older timm versions

### DIFF
--- a/sam3/model/memory.py
+++ b/sam3/model/memory.py
@@ -7,7 +7,11 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from timm.layers import DropPath
+try:
+    from timm.layers import DropPath
+except ModuleNotFoundError:
+    # compatibility for older timm versions
+    from timm.models.layers import DropPath
 
 from .model_misc import get_clones, LayerNorm2d
 

--- a/sam3/model/sam3_tracker_base.py
+++ b/sam3/model/sam3_tracker_base.py
@@ -13,7 +13,12 @@ from sam3.sam.mask_decoder import MaskDecoder, MLP
 from sam3.sam.prompt_encoder import PromptEncoder
 from sam3.sam.transformer import TwoWayTransformer
 from sam3.train.data.collator import BatchedDatapoint
-from timm.layers import trunc_normal_
+
+try:
+    from timm.layers import trunc_normal_
+except ModuleNotFoundError:
+    # compatibility for older timm versions
+    from timm.models.layers import trunc_normal_
 
 # a large negative value as a placeholder score for missing objects
 NO_OBJ_SCORE = -1024.0

--- a/sam3/model/vitdet.py
+++ b/sam3/model/vitdet.py
@@ -18,7 +18,12 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 import torch.utils.checkpoint as checkpoint
-from timm.layers import DropPath, Mlp, trunc_normal_
+
+try:
+    from timm.layers import DropPath, Mlp, trunc_normal_
+except ModuleNotFoundError:
+    # compatibility for older timm versions
+    from timm.models.layers import DropPath, Mlp, trunc_normal_
 from torch import Tensor
 
 from .model_misc import LayerScale


### PR DESCRIPTION
In this diff, we allow falling back to `timm.models.layers` for compatibility for older timm versions (this resolves an error in fbpkg)