### PR TITLE
[sam3] switch to `iter_use_prev_mask_pred=True` and `add_all_frames_to_correct_as_cond=True` to be consistent with our internal codebase

### DIFF
--- a/sam3/model/sam3_tracking_predictor.py
+++ b/sam3/model/sam3_tracking_predictor.py
@@ -4,11 +4,11 @@ import logging
 from collections import OrderedDict
 
 import torch
-from tqdm.auto import tqdm
 
 from sam3.model.sam3_tracker_base import concat_points, NO_OBJ_SCORE, Sam3TrackerBase
 from sam3.model.sam3_tracker_utils import fill_holes_in_mask_scores
 from sam3.model.utils.sam2_utils import load_video_frames
+from tqdm.auto import tqdm
 
 
 class Sam3TrackerPredictor(Sam3TrackerBase):


### PR DESCRIPTION
In this diff, we switch to `iter_use_prev_mask_pred=True` and `add_all_frames_to_correct_as_cond=True` to be consistent with our internal codebase.

Internally, we are using `iter_use_prev_mask_pred=True` and `add_all_frames_to_correct_as_cond=True` in `config/experiments/references/savi/savi_base_paper.yaml`, i.e. the base config all SAM 2 and SAM 3 VOS).