### PR TITLE
Remove 'qwen3_vl_8b_instruct' model configuration

### DIFF
--- a/examples/sam3_agent.ipynb
+++ b/examples/sam3_agent.ipynb
@@ -112,10 +112,6 @@
    "source": [
     "LLM_CONFIGS = {\n",
     "    # vLLM-served models\n",
-    "    \"qwen3_vl_8b_instruct\": {\n",
-    "        \"provider\": \"vllm\",\n",
-    "        \"model\": \"Qwen/Qwen3-VL-8B-Instruct\",\n",
-    "    },\n",
     "    \"qwen3_vl_8b_thinking\": {\n",
     "        \"provider\": \"vllm\",\n",
     "        \"model\": \"Qwen/Qwen3-VL-8B-Thinking\",\n",
@@ -152,9 +148,6 @@
     "  ```\n",
     "* Start vLLM server on the same machine of this notebook\n",
     "  ```bash\n",
-    "    # qwen 3 VL 8B instruct\n",
-    "    vllm serve Qwen/Qwen3-VL-8B-Instruct --tensor-parallel-size 4 --allowed-local-media-path / --enforce-eager --port 8001\n",
-    "\n",
     "    # qwen 3 VL 8B thinking\n",
     "    vllm serve Qwen/Qwen3-VL-8B-Thinking --tensor-parallel-size 4 --allowed-local-media-path / --enforce-eager --port 8001\n",
     "  ```"


### PR DESCRIPTION
Removed configuration for 'qwen3_vl_8b_instruct' model and its serving command.