### PR TITLE
fix the edge case of all negatives in a batch

### DIFF
--- a/sam3/train/loss/loss_fns.py
+++ b/sam3/train/loss/loss_fns.py
@@ -48,6 +48,9 @@ def instance_masks_to_semantic_masks(
         torch.Tensor: A tensor of shape (B, H, W) where B is the batch size and H, W are the spatial dimensions of the
             input instance masks.
     """
+    if num_instances.sum() == 0:
+        # all negative batch, create a tensor of zeros (B, 1, 1)
+        return num_instances.unsqueeze(-1).unsqueeze(-1)
 
     masks_per_query = torch.split(instance_masks, num_instances.tolist())
 


### PR DESCRIPTION
When all queries in this batch are negative, the semantic mask head loss broke, due to the wrong construction of target semantic masks.
This diff fix this edge case, by creating an dummy target semantic masks of all zero tensors of shape [B, 1, 1]