### PR TITLE
Fix  type annotation mismatch for `images` parameter  in sam3_image_processor.py

### DIFF
--- a/sam3/model/sam3_image_processor.py
+++ b/sam3/model/sam3_image_processor.py
@@ -73,7 +73,7 @@ class Sam3Processor:
         return state
 
     @torch.inference_mode()
-    def set_image_batch(self, images: List[np.ndarray], state=None):
+    def set_image_batch(self, images: List[PIL.Image.Image], state=None):
         """Sets the image batch on which we want to do predictions."""
         if state is None:
             state = {}


### PR DESCRIPTION
##  Question 

The type annotation for the `images` parameter in `set_image_batch` method does not match the runtime type check, causing confusion about expected input type.  (line 76-86)

```
def set_image_batch(self, images: List[np.ndarray], state=None):
    """Sets the image batch on which we want to do predictions."""
    if state is None:
        state = {}

    if not isinstance(images, list):
        raise ValueError("Images must be a list of PIL images or tensors")
    assert len(images) > 0, "Images list must not be empty"
    assert isinstance(
        images[0], PIL.Image.Image
    ), "Images must be a list of PIL images"
```

##  Solution

`images: List[np.ndarray] -> images: List[PIL.Image.Image]`
