### PR TITLE
Add pandas to notebooks optional dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ notebooks = [
     "einops",
     "scikit-image",
     "scikit-learn",
+    "pandas",
 ]
 train = [
     "hydra-core",


### PR DESCRIPTION
## Summary
Fixes a ModuleNotFoundError when running example notebooks after installing with `pip install -e ".[notebooks]"`.

## Problem
The `sam3.visualization_utils.plot_results()` function imports `pandas`, which is used in notebook examples (e.g., `sam3_image_batched_inference.ipynb`). However, `pandas` was only listed in the `dev` optional dependencies, not in the `notebooks` optional dependencies.

## Solution
Added `pandas` to the `notebooks` optional dependencies in `pyproject.toml`.

## Testing
- Installed with `pip install -e ".[notebooks]"`
- Successfully ran the import cell in `sam3_image_batched_inference.ipynb`
- Verified pyproject.toml syntax is valid