### PR TITLE
chore: update settings for setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,8 +82,8 @@ train = [
 "Homepage" = "https://github.com/facebookresearch/sam3"
 "Bug Tracker" = "https://github.com/facebookresearch/sam3/issues"
 
-[tool.setuptools]
-packages = ["sam3", "sam3.model"]
+[tool.setuptools.packages.find]
+include = ["sam3*"]
 
 [tool.setuptools.dynamic]
 version = {attr = "sam3.__version__"}


### PR DESCRIPTION
## What

This pull request updates the packaging configuration in `pyproject.toml` to improve how Python packages are discovered and included during installation.

**Packaging configuration improvements:**

* Switched from explicitly listing packages (`sam3`, `sam3.model`) to using `setuptools`' automatic package discovery with an `include` pattern (`sam3*`), making it easier to include all relevant subpackages.

## How Checked This PR?

If I install sam3 using `astral/uv` with the following `pyproject.toml`:

```toml
# pyproject.toml
[build-system]
requires = ["hatchling"]
build-backend = "hatchling.build"

[tool.hatch.metadata]
allow-direct-references = true

[tool.hatch.build.targets.wheel]
packages = ["foo"]

[project]
name = "foo"
version = "0.1.0"
description = "Add your description here"
readme = "README.md"
requires-python = ">=3.10"
dependencies = [
    "sam3@git+https://github.com/facebookresearch/sam3.git@main"
]
```

Install successfully, but it seems some modules are skipped installing as follows:

```shell
$ ls .venv/lib/python3.10/site-packages/sam3
__init__.py  logger.py  model  model_builder.py  visualization_utils.py
```

By installing sam3 with this branch, it looks OK:

```toml
# pyproject.toml
# ...
dependencies = [
    "sam3@git+https://github.com/ktro2828/sam3.git@chore/setuptools"
]
```

```shell
$ ls .venv/lib/python3.10/site-packages/sam3
agent  eval  __init__.py  logger.py  model  model_builder.py  perflib  sam  train  visualization_utils.py
```