### PR TITLE
Support device agnostic image inference (mps, cpu etc)

### DIFF
--- a/sam3/model/geometry_encoders.py
+++ b/sam3/model/geometry_encoders.py
@@ -613,9 +613,19 @@ class SequenceGeometryEncoder(nn.Module):
             grid = points.transpose(0, 1).unsqueeze(2)
             # re normalize to [-1, 1]
             grid = (grid * 2) - 1
-            sampled = torch.nn.functional.grid_sample(
-                img_feats, grid, align_corners=False
-            )
+
+            if img_feats.device.type == 'mps':
+                # MPS sometimes has issues with grid_sample - run on CPU and move back
+                img_feats_cpu = img_feats.cpu()
+                grid_cpu = grid.cpu()
+                sampled = torch.nn.functional.grid_sample(
+                    img_feats_cpu, grid_cpu, align_corners=False
+                ).to(img_feats.device)
+            else:
+                sampled = torch.nn.functional.grid_sample(
+                    img_feats, grid, align_corners=False
+                )
+
             assert list(sampled.shape) == [bs, self.d_model, n_points, 1]
             sampled = sampled.squeeze(-1).permute(2, 0, 1)
             proj = self.points_pool_project(sampled)
@@ -656,7 +666,10 @@ class SequenceGeometryEncoder(nn.Module):
             # We need to denormalize, and convert to [x, y, x, y]
             boxes_xyxy = box_cxcywh_to_xyxy(boxes)
             scale = torch.tensor([W, H, W, H], dtype=boxes_xyxy.dtype)
-            scale = scale.pin_memory().to(device=boxes_xyxy.device, non_blocking=True)
+            if boxes_xyxy.device.type == 'cuda':
+                scale = scale.pin_memory().to(device=boxes_xyxy.device, non_blocking=True)
+            else:
+                scale = scale.to(device=boxes_xyxy.device)
             scale = scale.view(1, 1, 4)
             boxes_xyxy = boxes_xyxy * scale
             sampled = torchvision.ops.roi_align(

--- a/sam3/model/position_encoding.py
+++ b/sam3/model/position_encoding.py
@@ -44,7 +44,7 @@ class PositionEmbeddingSine(nn.Module):
                 (precompute_resolution // 32, precompute_resolution // 32),
             ]
             for size in precompute_sizes:
-                tensors = torch.zeros((1, 1) + size, device="cuda")
+                tensors = torch.zeros((1, 1) + size)
                 self.forward(tensors)
                 # further clone and detach it in the cache (just to be safe)
                 self.cache[size] = self.cache[size].clone().detach()
@@ -90,7 +90,8 @@ class PositionEmbeddingSine(nn.Module):
         cache_key = None
         cache_key = (x.shape[-2], x.shape[-1])
         if cache_key in self.cache:
-            return self.cache[cache_key][None].repeat(x.shape[0], 1, 1, 1)
+            cached = self.cache[cache_key].to(x.device)
+            return cached[None].repeat(x.shape[0], 1, 1, 1)
         y_embed = (
             torch.arange(1, x.shape[-2] + 1, dtype=torch.float32, device=x.device)
             .view(1, -1, 1)

--- a/sam3/model/sam3_image_processor.py
+++ b/sam3/model/sam3_image_processor.py
@@ -14,10 +14,14 @@ from torchvision.transforms import v2
 class Sam3Processor:
     """ """
 
-    def __init__(self, model, resolution=1008, device="cuda", confidence_threshold=0.5):
+    def __init__(self, model, resolution=1008, device=None, confidence_threshold=0.5):
         self.model = model
         self.resolution = resolution
+
+        if device is None:
+            device = next(model.parameters()).device
         self.device = device
+        
         self.transform = v2.Compose(
             [
                 v2.ToDtype(torch.uint8, scale=True),

--- a/sam3/model/sam3_tracker_utils.py
+++ b/sam3/model/sam3_tracker_utils.py
@@ -5,7 +5,7 @@ import torch
 import torch.nn.functional as F
 from numpy.typing import NDArray
 
-from sam3.model.edt import edt_triton
+
 
 
 def sample_box_points(
@@ -175,6 +175,8 @@ def sample_one_point_from_error_center(gt_masks, pred_masks, padding=True):
         padded_fp_masks = fp_masks
         padded_fn_masks = fn_masks
 
+    from sam3.model.edt import edt_triton
+    
     fn_mask_dt = edt_triton(padded_fn_masks)
     fp_mask_dt = edt_triton(padded_fp_masks)
     if padding:

--- a/sam3/model/sam3_tracking_predictor.py
+++ b/sam3/model/sam3_tracking_predictor.py
@@ -46,7 +46,11 @@ class Sam3TrackerPredictor(Sam3TrackerBase):
         self.max_point_num_in_prompt_enc = max_point_num_in_prompt_enc
         self.non_overlap_masks_for_output = non_overlap_masks_for_output
 
-        self.bf16_context = torch.autocast(device_type="cuda", dtype=torch.bfloat16)
+        device_type = next(self.parameters()).device.type
+        if device_type == "mps":
+            self.bf16_context = torch.autocast(device_type="mps", dtype=torch.float16)
+        else:
+            self.bf16_context = torch.autocast(device_type, dtype=torch.bfloat16)
         self.bf16_context.__enter__()  # keep using for the entire model process
 
         self.iter_use_prev_mask_pred = True

--- a/sam3/train/data/sam3_image_dataset.py
+++ b/sam3/train/data/sam3_image_dataset.py
@@ -15,7 +15,6 @@ from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
 import torch
 import torch.utils.data
 import torchvision
-from decord import cpu, VideoReader
 from iopath.common.file_io import g_pathmgr
 
 from PIL import Image as PILImage
@@ -201,6 +200,8 @@ class CustomCocoDetectionAPI(VisionDataset):
             path = os.path.join(self.root, path)
             try:
                 if ".mp4" in path and path[-4:] == ".mp4":
+                    from decord import cpu, VideoReader
+
                     # Going to load a video frame
                     video_path, frame = path.split("@")
                     video = VideoReader(video_path, ctx=cpu(0))


### PR DESCRIPTION
Partially fixes https://github.com/facebookresearch/sam3/issues/164

This PR removes hardcoded CUDA parameters for image inference. The default is still to use CUDA if available. Video is still unsupported, but could probably be fixed as that seems to be a dataloading issue. I've tested on the single and batch inference notebooks.

I've kept changes as minimal as possible for demonstration/review. `triton` and `decord` only cause issues in a couple of places, and my fix here is to move the import statements to where the code is called. These paths don't trigger during inference. 

In the position encoder, the precomputed cache also defaulted to CUDA. I'm open to a clean suggestion here e.g. creating the entries on CPU and updating the first time the cache is accessed?

In the decoder, one call to `_get_coords` defaulted to CUDA which I've moved to CPU. This helper is only(?) called by `_get_rpb_matrix` and the coords are moved to device there.

A better fix might be to have these modules take a device parameter, but that gets quite messy adding `device` to all the calling functions up the chain. Probably the most performant route if that's preferable.

`torch.nn.functional.grid_sample` should gracefully fallback to CPU, but I get an assertion on an M2 device, hence the explicit conversion to CPU and back. That's awkward but it only affects MPS.

To test, run the example notebook with the following change. All the playground image examples work for me.

```python
os.environ.setdefault('PYTORCH_ENABLE_MPS_FALLBACK', '1')
bpe_path = f"{sam3_root}/assets/bpe_simple_vocab_16e6.txt.gz"
model = build_sam3_image_model(bpe_path=bpe_path)
print(model.device)

> mps:0
```

Batching should also work, but I get an OOM on my laptop - so I assume the forward pass is working.