### PR TITLE
Fallback to opencv in case triton is not supported

### DIFF
--- a/sam3/model/edt.py
+++ b/sam3/model/edt.py
@@ -2,9 +2,31 @@
 
 """Triton kernel for euclidean distance transform (EDT)"""
 
+import logging
+
 import torch
-import triton
-import triton.language as tl
+
+try:
+    import triton
+    import triton.language as tl
+
+    HAS_TRITON = True
+except ImportError:
+    logging.debug(
+        "triton not found. Falling back to OpenCV for EDT computation. "
+        "Triton is not available on Windows. For Linux, install with: pip install triton"
+    )
+    HAS_TRITON = False
+    try:
+        import cv2
+        import numpy as np
+
+        HAS_OPENCV = True
+    except ImportError:
+        logging.warning(
+            "OpenCV not found. EDT computation will fail. Install with: pip install opencv-python"
+        )
+        HAS_OPENCV = False
 
 """
 Disclaimer: This implementation is not meant to be extremely efficient. A CUDA kernel would likely be more efficient.
@@ -50,68 +72,70 @@ Overall, despite being quite naive, this implementation is roughly 5.5x faster t
 """
 
 
-@triton.jit
-def edt_kernel(inputs_ptr, outputs_ptr, v, z, height, width, horizontal: tl.constexpr):
-    # This is a somewhat verbatim implementation of the efficient 1D EDT algorithm described above
-    # It can be applied horizontally or vertically depending if we're doing the first or second stage.
-    # It's parallelized across batch+row (or batch+col if horizontal=False)
-    # TODO: perhaps the implementation can be revisited if/when local gather/scatter become available in triton
-    batch_id = tl.program_id(axis=0)
-    if horizontal:
-        row_id = tl.program_id(axis=1)
-        block_start = (batch_id * height * width) + row_id * width
-        length = width
-        stride = 1
-    else:
-        col_id = tl.program_id(axis=1)
-        block_start = (batch_id * height * width) + col_id
-        length = height
-        stride = width
+if HAS_TRITON:
 
-    # This will be the index of the right most parabola in the envelope ("the top of the stack")
-    k = 0
-    for q in range(1, length):
-        # Read the function value at the current location. Note that we're doing a singular read, not very efficient
-        cur_input = tl.load(inputs_ptr + block_start + (q * stride))
-        # location of the parabola on top of the stack
-        r = tl.load(v + block_start + (k * stride))
-        # associated boundary
-        z_k = tl.load(z + block_start + (k * stride))
-        # value of the function at the parabola location
-        previous_input = tl.load(inputs_ptr + block_start + (r * stride))
-        # intersection between the two parabolas
-        s = (cur_input - previous_input + q * q - r * r) / (q - r) / 2
+    @triton.jit
+    def edt_kernel(inputs_ptr, outputs_ptr, v, z, height, width, horizontal: tl.constexpr):
+        # This is a somewhat verbatim implementation of the efficient 1D EDT algorithm described above
+        # It can be applied horizontally or vertically depending if we're doing the first or second stage.
+        # It's parallelized across batch+row (or batch+col if horizontal=False)
+        # TODO: perhaps the implementation can be revisited if/when local gather/scatter become available in triton
+        batch_id = tl.program_id(axis=0)
+        if horizontal:
+            row_id = tl.program_id(axis=1)
+            block_start = (batch_id * height * width) + row_id * width
+            length = width
+            stride = 1
+        else:
+            col_id = tl.program_id(axis=1)
+            block_start = (batch_id * height * width) + col_id
+            length = height
+            stride = width
 
-        # we'll pop as many parabolas as required
-        while s <= z_k and k - 1 >= 0:
-            k = k - 1
+        # This will be the index of the right most parabola in the envelope ("the top of the stack")
+        k = 0
+        for q in range(1, length):
+            # Read the function value at the current location. Note that we're doing a singular read, not very efficient
+            cur_input = tl.load(inputs_ptr + block_start + (q * stride))
+            # location of the parabola on top of the stack
             r = tl.load(v + block_start + (k * stride))
+            # associated boundary
             z_k = tl.load(z + block_start + (k * stride))
+            # value of the function at the parabola location
             previous_input = tl.load(inputs_ptr + block_start + (r * stride))
+            # intersection between the two parabolas
             s = (cur_input - previous_input + q * q - r * r) / (q - r) / 2
 
-        # Store the new one
-        k = k + 1
-        tl.store(v + block_start + (k * stride), q)
-        tl.store(z + block_start + (k * stride), s)
-        if k + 1 < length:
-            tl.store(z + block_start + ((k + 1) * stride), 1e9)
+            # we'll pop as many parabolas as required
+            while s <= z_k and k - 1 >= 0:
+                k = k - 1
+                r = tl.load(v + block_start + (k * stride))
+                z_k = tl.load(z + block_start + (k * stride))
+                previous_input = tl.load(inputs_ptr + block_start + (r * stride))
+                s = (cur_input - previous_input + q * q - r * r) / (q - r) / 2
 
-    # Last step, we read the envelope to find the min in every location
-    k = 0
-    for q in range(length):
-        while (
-            k + 1 < length
-            and tl.load(
-                z + block_start + ((k + 1) * stride), mask=(k + 1) < length, other=q
-            )
-            < q
-        ):
-            k += 1
-        r = tl.load(v + block_start + (k * stride))
-        d = q - r
-        old_value = tl.load(inputs_ptr + block_start + (r * stride))
-        tl.store(outputs_ptr + block_start + (q * stride), old_value + d * d)
+            # Store the new one
+            k = k + 1
+            tl.store(v + block_start + (k * stride), q)
+            tl.store(z + block_start + (k * stride), s)
+            if k + 1 < length:
+                tl.store(z + block_start + ((k + 1) * stride), 1e9)
+
+        # Last step, we read the envelope to find the min in every location
+        k = 0
+        for q in range(length):
+            while (
+                k + 1 < length
+                and tl.load(
+                    z + block_start + ((k + 1) * stride), mask=(k + 1) < length, other=q
+                )
+                < q
+            ):
+                k += 1
+            r = tl.load(v + block_start + (k * stride))
+            d = q - r
+            old_value = tl.load(inputs_ptr + block_start + (r * stride))
+            tl.store(outputs_ptr + block_start + (q * stride), old_value + d * d)
 
 
 def edt_triton(data: torch.Tensor):
@@ -126,48 +150,66 @@ def edt_triton(data: torch.Tensor):
         It should be equivalent to a batched version of cv2.distanceTransform(input, cv2.DIST_L2, 0)
     """
     assert data.dim() == 3
-    assert data.is_cuda
     B, H, W = data.shape
     data = data.contiguous()
 
-    # Allocate the "function" tensor. Implicitly the function is 0 if data[i,j]==0 else +infinity
-    output = torch.where(data, 1e18, 0.0)
-    assert output.is_contiguous()
+    if HAS_TRITON and data.is_cuda:
+        # Use Triton implementation for CUDA
+        assert data.is_cuda
+        # Allocate the "function" tensor. Implicitly the function is 0 if data[i,j]==0 else +infinity
+        output = torch.where(data, 1e18, 0.0)
+        assert output.is_contiguous()
 
-    # Scratch tensors for the parabola stacks
-    parabola_loc = torch.zeros(B, H, W, dtype=torch.uint32, device=data.device)
-    parabola_inter = torch.empty(B, H, W, dtype=torch.float, device=data.device)
-    parabola_inter[:, :, 0] = -1e18
-    parabola_inter[:, :, 1] = 1e18
+        # Scratch tensors for the parabola stacks
+        parabola_loc = torch.zeros(B, H, W, dtype=torch.uint32, device=data.device)
+        parabola_inter = torch.empty(B, H, W, dtype=torch.float, device=data.device)
+        parabola_inter[:, :, 0] = -1e18
+        parabola_inter[:, :, 1] = 1e18
 
-    # Grid size (number of blocks)
-    grid = (B, H)
+        # Grid size (number of blocks)
+        grid = (B, H)
 
-    # Launch initialization kernel
-    edt_kernel[grid](
-        output.clone(),
-        output,
-        parabola_loc,
-        parabola_inter,
-        H,
-        W,
-        horizontal=True,
-    )
+        # Launch initialization kernel
+        edt_kernel[grid](
+            output.clone(),
+            output,
+            parabola_loc,
+            parabola_inter,
+            H,
+            W,
+            horizontal=True,
+        )
 
-    # reset the parabola stacks
-    parabola_loc.zero_()
-    parabola_inter[:, :, 0] = -1e18
-    parabola_inter[:, :, 1] = 1e18
+        # reset the parabola stacks
+        parabola_loc.zero_()
+        parabola_inter[:, :, 0] = -1e18
+        parabola_inter[:, :, 1] = 1e18
 
-    grid = (B, W)
-    edt_kernel[grid](
-        output.clone(),
-        output,
-        parabola_loc,
-        parabola_inter,
-        H,
-        W,
-        horizontal=False,
-    )
-    # don't forget to take sqrt at the end
-    return output.sqrt()
+        grid = (B, W)
+        edt_kernel[grid](
+            output.clone(),
+            output,
+            parabola_loc,
+            parabola_inter,
+            H,
+            W,
+            horizontal=False,
+        )
+        # don't forget to take sqrt at the end
+        return output.sqrt()
+    elif HAS_OPENCV:
+        # Fallback to OpenCV implementation
+        device = data.device
+        data_np = data.cpu().numpy().astype(np.uint8)
+        output_list = []
+        for b in range(B):
+            dt = cv2.distanceTransform(data_np[b], cv2.DIST_L2, 0)
+            output_list.append(torch.from_numpy(dt).float())
+        output = torch.stack(output_list, dim=0).to(device)
+        return output
+    else:
+        raise RuntimeError(
+            "Neither triton nor OpenCV is available. Please install one of them:\n"
+            "  - For Linux: pip install triton\n"
+            "  - For Windows/fallback: pip install opencv-python"
+        )


### PR DESCRIPTION
**PROBLEM**
The current implementation uses Triton kernel for euclidean distance transform (EDT) which is not supported or difficult to install  for windows users. 

**SOLUTION**
Fallback to OpenCV to run on windows environment directly.