### PR TITLE
Fix device mismatch in TransformerDecoder to enable CPU inference

### DIFF
--- a/sam3/model/decoder.py
+++ b/sam3/model/decoder.py
@@ -278,7 +278,7 @@ class TransformerDecoder(nn.Module):
             if resolution is not None and stride is not None:
                 feat_size = resolution // stride
                 coords_h, coords_w = self._get_coords(
-                    feat_size, feat_size, device="cuda"
+                    feat_size, feat_size, device=next(layer.parameters()).device
                 )
                 self.compilable_cord_cache = (coords_h, coords_w)
                 self.compilable_stored_size = (feat_size, feat_size)


### PR DESCRIPTION
Fixes a device mismatch error (“Expected all tensors to be on the same device”) caused by hard-coded device usage in TransformerDecoder coordinate computations. This update removes the fixed device assignment and enables inference on non-CUDA devices such as CPU.

```
Exception has occurred: RuntimeError       (note: full exception trace is shown but execution is paused at: _run_module_as_main)
Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!
  File "REDACTED/sam3/sam3/model/decoder.py", line 357, in _get_rpb_matrix
    deltas_y = coords_h.view(1, -1, 1) - boxes_xyxy.reshape(-1, 1, 4)[:, :, 1:4:2]
```