### PR TITLE
Lazy import decord to avoid a hard dependency on it

### DIFF
--- a/sam3/train/data/sam3_image_dataset.py
+++ b/sam3/train/data/sam3_image_dataset.py
@@ -15,7 +15,6 @@ from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
 import torch
 import torch.utils.data
 import torchvision
-from decord import cpu, VideoReader
 from iopath.common.file_io import g_pathmgr
 
 from PIL import Image as PILImage
@@ -181,6 +180,9 @@ class CustomCocoDetectionAPI(VisionDataset):
     def _load_images(
         self, datapoint_id: int, img_ids_to_load: Optional[Set[int]] = None
     ) -> Tuple[List[Tuple[int, PILImage.Image]], List[Dict[str, Any]]]:
+        # Lazy load decord to avoid a hard dependency on it on the sam3
+        # package as a whole
+        from decord import cpu, VideoReader
         all_images = []
         all_img_metadata = []
         for current_meta in self.coco.loadImagesFromDatapoint(datapoint_id):


### PR DESCRIPTION
A simpler alternative to https://github.com/facebookresearch/sam3/pull/192 avoiding decord as a hard dependency