### PR TITLE
Fix _on_clear_prompts in interactive example notebook

### DIFF
--- a/examples/sam3_image_interactive.ipynb
+++ b/examples/sam3_image_interactive.ipynb
@@ -430,7 +430,7 @@
     "        if self.current_image is not None:\n",
     "            try:\n",
     "                self._set_loading(True, \"Clearing prompts and resetting...\")\n",
-    "                self.state = self.processor.reset_all_prompts(self.state)\n",
+    "                self.processor.reset_all_prompts(self.state)\n",
     "                if \"prompted_boxes\" in self.state:\n",
     "                    del self.state[\"prompted_boxes\"]\n",
     "                self.text_input.value = \"\"\n",


### PR DESCRIPTION
The Sam3Processor's method "reset_all_prompts'" does not return the state