### PR TITLE
Fixing "Clear All Prompts" functionality on Notebook Example

### DIFF
--- a/examples/sam3_image_interactive.ipynb
+++ b/examples/sam3_image_interactive.ipynb
@@ -430,9 +430,9 @@
     "        if self.current_image is not None:\n",
     "            try:\n",
     "                self._set_loading(True, \"Clearing prompts and resetting...\")\n",
-    "                self.state = self.processor.reset_all_prompts(self.state)\n",
-    "                if \"prompted_boxes\" in self.state:\n",
-    "                    del self.state[\"prompted_boxes\"]\n",
+    "                image_placeholder = self.current_image
+    "                self.state = self.processor.reset_all_prompts(self.state)
+    "                self.state = self.processor.set_image(image_placeholder)
     "                self.text_input.value = \"\"\n",
     "                self._set_loading(False)\n",
     "                self.status_label.value = \"Cleared all prompts\"\n",


### PR DESCRIPTION
When clicking, the process would break due to trying to iterate on 'self.state' (which is None). Even fixing this, the code would break due to erasing the image from the processor.

I'm not the most versatile in coding, but this fixed the issue.