### PR TITLE
Add Apple Silicon (MPS) support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 dependencies = [
     "timm>=1.0.17",
-    "numpy==1.26",
+    "numpy==1.26.4",
     "tqdm",
     "ftfy==6.1.1",
     "regex",
@@ -59,7 +59,7 @@ notebooks = [
     "ipycanvas",
     "ipympl",
     "pycocotools",
-    "decord",
+    "decord2",
     "opencv-python",
     "einops",
     "scikit-image",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 dependencies = [
     "timm>=1.0.17",
-    "numpy==1.26.4",
+    "numpy>=1.26",
     "tqdm",
     "ftfy==6.1.1",
     "regex",

--- a/sam3/eval/postprocessors.py
+++ b/sam3/eval/postprocessors.py
@@ -150,9 +150,13 @@ class PostProcessImage(nn.Module):
         if pred_masks is None:
             return None
         if self.always_interpolate_masks_on_gpu:
-            gpu_device = target_sizes.device
-            assert gpu_device.type == "cuda"
-            pred_masks = pred_masks.to(device=gpu_device)
+            device = target_sizes.device
+            if device.type == "cpu":
+                logging.warning(
+                    "always_interpolate_masks_on_gpu=True but data is on CPU; "
+                    "falling back to CPU interpolation"
+                )
+            pred_masks = pred_masks.to(device=device)
         if consistent:
             assert keep is None, "TODO: implement?"
             # All masks should have the same shape, expected when processing a batch of size 1
@@ -454,9 +458,13 @@ class PostProcessAPIVideo(PostProcessImage):
             ]  # [P,Q,...] --> [K,...]
             meta_td = meta_td[tracked_obj_ids_idx[PROMPT_AXIS].cpu()]
             if self.always_interpolate_masks_on_gpu:
-                gpu_device = meta_td["original_size"].device
-                assert gpu_device.type == "cuda"
-                tracked_objs_outs_td = tracked_objs_outs_td.to(device=gpu_device)
+                device = meta_td["original_size"].device
+                if device.type == "cpu":
+                    logging.warning(
+                        "always_interpolate_masks_on_gpu=True but data is on CPU; "
+                        "falling back to CPU interpolation"
+                    )
+                tracked_objs_outs_td = tracked_objs_outs_td.to(device=device)
             frame_results_td = self(
                 tracked_objs_outs_td.unsqueeze(1),
                 (

--- a/sam3/model/decoder.py
+++ b/sam3/model/decoder.py
@@ -277,8 +277,9 @@ class TransformerDecoder(nn.Module):
 
             if resolution is not None and stride is not None:
                 feat_size = resolution // stride
+                device = "cuda" if torch.cuda.is_available() else "cpu"
                 coords_h, coords_w = self._get_coords(
-                    feat_size, feat_size, device="cuda"
+                    feat_size, feat_size, device=device
                 )
                 self.compilable_cord_cache = (coords_h, coords_w)
                 self.compilable_stored_size = (feat_size, feat_size)

--- a/sam3/model/decoder.py
+++ b/sam3/model/decoder.py
@@ -23,6 +23,7 @@ from .model_misc import (
     gen_sineembed_for_position,
     get_activation_fn,
     get_clones,
+    get_default_device,
     inverse_sigmoid,
     MLP,
 )
@@ -277,7 +278,7 @@ class TransformerDecoder(nn.Module):
 
             if resolution is not None and stride is not None:
                 feat_size = resolution // stride
-                device = "cuda" if torch.cuda.is_available() else "cpu"
+                device = get_default_device()
                 coords_h, coords_w = self._get_coords(
                     feat_size, feat_size, device=device
                 )
@@ -343,6 +344,11 @@ class TransformerDecoder(nn.Module):
         ):
             # good, hitting the cache, will be compilable
             coords_h, coords_w = self.compilable_cord_cache
+            # Ensure cache is on the same device as input (handles model.to(device) calls)
+            if coords_h.device != reference_boxes.device:
+                coords_h = coords_h.to(reference_boxes.device)
+                coords_w = coords_w.to(reference_boxes.device)
+                self.compilable_cord_cache = (coords_h, coords_w)
         else:
             # cache miss, will create compilation issue
             # In case we're not compiling, we'll still rely on the dict-based cache

--- a/sam3/model/geometry_encoders.py
+++ b/sam3/model/geometry_encoders.py
@@ -10,7 +10,7 @@ from typing_extensions import override
 from .act_ckpt_utils import activation_ckpt_wrapper
 from .box_ops import box_cxcywh_to_xyxy
 
-from .model_misc import get_clones
+from .model_misc import get_clones, tensor_to_device
 
 
 def is_right_padded(mask):
@@ -656,7 +656,7 @@ class SequenceGeometryEncoder(nn.Module):
             # We need to denormalize, and convert to [x, y, x, y]
             boxes_xyxy = box_cxcywh_to_xyxy(boxes)
             scale = torch.tensor([W, H, W, H], dtype=boxes_xyxy.dtype)
-            scale = scale.pin_memory().to(device=boxes_xyxy.device, non_blocking=True)
+            scale = tensor_to_device(scale, boxes_xyxy.device)
             scale = scale.view(1, 1, 4)
             boxes_xyxy = boxes_xyxy * scale
             sampled = torchvision.ops.roi_align(

--- a/sam3/model/io_utils.py
+++ b/sam3/model/io_utils.py
@@ -15,6 +15,7 @@ import torchvision.transforms.functional as TF
 from PIL import Image
 
 from sam3.logger import get_logger
+from sam3.model.model_misc import get_default_device
 from tqdm import tqdm
 
 logger = get_logger(__name__)
@@ -48,7 +49,7 @@ def load_resource_as_video_frames(
     Alternatively, if input is a list of PIL images, convert its format
     """
     if device is None:
-        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        device = get_default_device()
     float_dtype = _get_float_dtype(device)
     if isinstance(resource_path, list):
         img_mean = torch.tensor(img_mean, dtype=float_dtype)[:, None, None]
@@ -112,7 +113,7 @@ def load_image_as_single_frame_video(
 ):
     """Load an image as a single-frame video."""
     if device is None:
-        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        device = get_default_device()
     float_dtype = _get_float_dtype(device)
     images, image_height, image_width = _load_img_as_tensor(image_path, image_size)
     images = images.unsqueeze(0).to(float_dtype)
@@ -144,7 +145,7 @@ def load_video_frames(
     the model and are loaded to GPU if offload_video_to_cpu=False. This is used by the demo.
     """
     if device is None:
-        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        device = get_default_device()
     assert isinstance(video_path, str)
     if video_path.startswith("<load-dummy-video"):
         # Check for pattern <load-dummy-video-N> where N is an integer
@@ -300,7 +301,7 @@ def load_video_frames_from_video_file_using_cv2(
     import cv2  # delay OpenCV import to avoid unnecessary dependency
 
     if device is None:
-        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        device = get_default_device()
     float_dtype = _get_float_dtype(device)
 
     # Initialize video capture

--- a/sam3/model/model_misc.py
+++ b/sam3/model/model_misc.py
@@ -28,6 +28,20 @@ def inverse_sigmoid(x, eps=1e-3):
     return torch.log(x1 / x2)
 
 
+def get_default_device() -> torch.device:
+    """
+    Get the default device for tensor operations.
+
+    Returns cuda if available, then mps if available, otherwise cpu.
+    """
+    if torch.cuda.is_available():
+        return torch.device("cuda")
+    elif torch.backends.mps.is_available():
+        return torch.device("mps")
+    else:
+        return torch.device("cpu")
+
+
 def tensor_to_device(tensor: Tensor, device: torch.device) -> Tensor:
     """
     Transfer a tensor to the target device efficiently.

--- a/sam3/model/model_misc.py
+++ b/sam3/model/model_misc.py
@@ -28,6 +28,26 @@ def inverse_sigmoid(x, eps=1e-3):
     return torch.log(x1 / x2)
 
 
+def tensor_to_device(tensor: Tensor, device: torch.device) -> Tensor:
+    """
+    Transfer a tensor to the target device efficiently.
+
+    For CUDA devices, uses pin_memory() for faster CPU→GPU transfers.
+    For other devices (MPS, CPU), uses direct .to() transfer.
+
+    Args:
+        tensor: The tensor to transfer (should be on CPU)
+        device: The target device
+
+    Returns:
+        The tensor on the target device
+    """
+    if device.type == "cuda":
+        return tensor.pin_memory().to(device=device, non_blocking=True)
+    else:
+        return tensor.to(device=device)
+
+
 class MultiheadAttentionWrapper(nn.MultiheadAttention):
     def forward(self, *args, **kwargs):
         kwargs["need_weights"] = False

--- a/sam3/model/position_encoding.py
+++ b/sam3/model/position_encoding.py
@@ -6,6 +6,8 @@ from typing import Optional
 import torch
 from torch import nn
 
+from .model_misc import get_default_device
+
 
 class PositionEmbeddingSine(nn.Module):
     """
@@ -43,7 +45,7 @@ class PositionEmbeddingSine(nn.Module):
                 (precompute_resolution // 16, precompute_resolution // 16),
                 (precompute_resolution // 32, precompute_resolution // 32),
             ]
-            device = "cuda" if torch.cuda.is_available() else "cpu"
+            device = get_default_device()
             for size in precompute_sizes:
                 tensors = torch.zeros((1, 1) + size, device=device)
                 self.forward(tensors)

--- a/sam3/model/position_encoding.py
+++ b/sam3/model/position_encoding.py
@@ -43,8 +43,9 @@ class PositionEmbeddingSine(nn.Module):
                 (precompute_resolution // 16, precompute_resolution // 16),
                 (precompute_resolution // 32, precompute_resolution // 32),
             ]
+            device = "cuda" if torch.cuda.is_available() else "cpu"
             for size in precompute_sizes:
-                tensors = torch.zeros((1, 1) + size, device="cuda")
+                tensors = torch.zeros((1, 1) + size, device=device)
                 self.forward(tensors)
                 # further clone and detach it in the cache (just to be safe)
                 self.cache[size] = self.cache[size].clone().detach()

--- a/sam3/model/sam3_image.py
+++ b/sam3/model/sam3_image.py
@@ -836,7 +836,10 @@ class Sam3ImageOnVideoMultiGPU(Sam3Image):
             assert len(feats["backbone_fpn"]) == 3  # SAM2 backbone always have 3 levels
             # cast the SAM2 backbone features to bfloat16 for all-gather (this is usually
             # a no-op, SAM2 backbone features are likely already in bfloat16 due to AMP)
-            backbone_fpn_bf16 = [x.to(torch.bfloat16) for x in feats["backbone_fpn"]]
+            if torch.cuda.is_available():
+                backbone_fpn_bf16 = [x.to(torch.bfloat16) for x in feats["backbone_fpn"]]
+            else:
+                backbone_fpn_bf16 = list(feats["backbone_fpn"])
             fpn0, fpn_handle0 = self._gather_tensor(backbone_fpn_bf16[0])
             fpn1, fpn_handle1 = self._gather_tensor(backbone_fpn_bf16[1])
             fpn2, fpn_handle2 = self._gather_tensor(backbone_fpn_bf16[2])

--- a/sam3/model/sam3_image.py
+++ b/sam3/model/sam3_image.py
@@ -122,7 +122,10 @@ class Sam3Image(torch.nn.Module):
                 # If this assert fails, it likely means we're requesting different img_ids (perhaps a different frame?)
                 # We currently don't expect this to happen. We could technically trigger a recompute here,
                 # but likely at the cost of a cpu<->gpu sync point, which would deteriorate perf
-                torch._assert_async((img_ids >= 0).all())
+                if img_ids.is_cuda:
+                    torch._assert_async((img_ids >= 0).all())
+                else:
+                    assert (img_ids >= 0).all(), "img_ids must be non-negative"
 
             vis_feats = backbone_out["backbone_fpn"][-self.num_feature_levels :]
             vis_pos_enc = backbone_out["vision_pos_enc"][-self.num_feature_levels :]

--- a/sam3/model/sam3_image_processor.py
+++ b/sam3/model/sam3_image_processor.py
@@ -14,9 +14,11 @@ from torchvision.transforms import v2
 class Sam3Processor:
     """ """
 
-    def __init__(self, model, resolution=1008, device="cuda", confidence_threshold=0.5):
+    def __init__(self, model, resolution=1008, device=None, confidence_threshold=0.5):
         self.model = model
         self.resolution = resolution
+        if device is None:
+            device = "cuda" if torch.cuda.is_available() else "cpu"
         self.device = device
         self.transform = v2.Compose(
             [

--- a/sam3/model/sam3_image_processor.py
+++ b/sam3/model/sam3_image_processor.py
@@ -8,6 +8,7 @@ import torch
 from sam3.model import box_ops
 
 from sam3.model.data_misc import FindStage, interpolate
+from sam3.model.model_misc import get_default_device
 from torchvision.transforms import v2
 
 
@@ -18,7 +19,7 @@ class Sam3Processor:
         self.model = model
         self.resolution = resolution
         if device is None:
-            device = "cuda" if torch.cuda.is_available() else "cpu"
+            device = get_default_device()
         self.device = device
         self.transform = v2.Compose(
             [

--- a/sam3/model/sam3_tracker_base.py
+++ b/sam3/model/sam3_tracker_base.py
@@ -790,6 +790,13 @@ class Sam3TrackerBase(torch.nn.Module):
             feat_sizes=feat_sizes,
             num_obj_ptr_tokens=num_obj_ptr_tokens,
         )
+
+        # MPS memory management: Synchronize and clear caches after encoder
+        # to prevent MPSGraph command queue buildup and memory leaks
+        if device.type == "mps":
+            torch.mps.synchronize()
+            torch.mps.empty_cache()
+
         # reshape the output (HW)BC => BCHW
         pix_feat_with_mem = encoder_out["memory"].permute(1, 2, 0).view(B, C, H, W)
         return pix_feat_with_mem

--- a/sam3/model/sam3_tracker_base.py
+++ b/sam3/model/sam3_tracker_base.py
@@ -6,7 +6,7 @@ import torch
 import torch.nn.functional as F
 
 from sam3.model.memory import SimpleMaskEncoder
-
+from sam3.model.model_misc import tensor_to_device
 from sam3.model.sam3_tracker_utils import get_1d_sine_pe, select_closest_cond_frames
 
 from sam3.sam.mask_decoder import MaskDecoder, MLP
@@ -165,7 +165,7 @@ class Sam3TrackerBase(torch.nn.Module):
 
         t_diff_max = max_abs_pos - 1 if max_abs_pos is not None else 1
         pos_enc = (
-            torch.tensor(rel_pos_list).pin_memory().to(device=device, non_blocking=True)
+            tensor_to_device(torch.tensor(rel_pos_list), device)
             / t_diff_max
         )
         tpos_dim = self.hidden_dim
@@ -653,15 +653,15 @@ class Sam3TrackerBase(torch.nn.Module):
                 if prev is None:
                     continue  # skip padding frames
                 # "maskmem_features" might have been offloaded to CPU in demo use cases,
-                # so we load it back to GPU (it's a no-op if it's already on GPU).
-                feats = prev["maskmem_features"].cuda(non_blocking=True)
+                # so we load it back to device (it's a no-op if it's already on device).
+                feats = prev["maskmem_features"].to(device, non_blocking=torch.cuda.is_available())
                 seq_len = feats.shape[-2] * feats.shape[-1]
                 to_cat_prompt.append(feats.flatten(2).permute(2, 0, 1))
                 to_cat_prompt_mask.append(
                     torch.zeros(B, seq_len, device=device, dtype=bool)
                 )
                 # Spatial positional encoding (it might have been offloaded to CPU in eval)
-                maskmem_enc = prev["maskmem_pos_enc"][-1].cuda()
+                maskmem_enc = prev["maskmem_pos_enc"][-1].to(device)
                 maskmem_enc = maskmem_enc.flatten(2).permute(2, 0, 1)
 
                 if (

--- a/sam3/model/sam3_tracking_predictor.py
+++ b/sam3/model/sam3_tracking_predictor.py
@@ -874,6 +874,12 @@ class Sam3TrackerPredictor(Sam3TrackerBase):
             low_res_masks, video_res_masks = self._get_orig_video_res_output(
                 inference_state, pred_masks
             )
+
+            # MPS synchronization to prevent command queue buildup and memory leaks
+            # This forces completion of all pending MPS operations before continuing
+            if inference_state["device"].type == "mps":
+                torch.mps.synchronize()
+
             yield frame_idx, obj_ids, low_res_masks, video_res_masks, obj_scores
 
     def _add_output_per_object(

--- a/sam3/model/sam3_video_predictor.py
+++ b/sam3/model/sam3_video_predictor.py
@@ -16,6 +16,7 @@ import psutil
 import torch
 
 from sam3.logger import get_logger
+from sam3.model.model_misc import get_default_device
 
 logger = get_logger(__name__)
 
@@ -40,10 +41,7 @@ class Sam3VideoPredictor:
         from sam3.model_builder import build_sam3_video_model
 
         # Determine device
-        if torch.cuda.is_available():
-            self.device = torch.device("cuda")
-        else:
-            self.device = torch.device("cpu")
+        self.device = get_default_device()
 
         logger.info(f"Sam3VideoPredictor using device: {self.device}")
 

--- a/sam3/model/sam3_video_predictor.py
+++ b/sam3/model/sam3_video_predictor.py
@@ -39,6 +39,14 @@ class Sam3VideoPredictor:
         self.video_loader_type = video_loader_type
         from sam3.model_builder import build_sam3_video_model
 
+        # Determine device
+        if torch.cuda.is_available():
+            self.device = torch.device("cuda")
+        else:
+            self.device = torch.device("cpu")
+
+        logger.info(f"Sam3VideoPredictor using device: {self.device}")
+
         self.model = (
             build_sam3_video_model(
                 checkpoint_path=checkpoint_path,
@@ -48,7 +56,7 @@ class Sam3VideoPredictor:
                 strict_state_dict_loading=strict_state_dict_loading,
                 apply_temporal_disambiguation=apply_temporal_disambiguation,
             )
-            .cuda()
+            .to(self.device)
             .eval()
         )
 
@@ -265,21 +273,27 @@ class Sam3VideoPredictor:
             f"'{session_id}' ({session['state']['num_frames']} frames)"
             for session_id, session in self._ALL_INFERENCE_STATES.items()
         ]
-        session_stats_str = (
-            f"live sessions: [{', '.join(live_session_strs)}], GPU memory: "
-            f"{torch.cuda.memory_allocated() // 1024**2} MiB used and "
-            f"{torch.cuda.memory_reserved() // 1024**2} MiB reserved"
-            f" (max over time: {torch.cuda.max_memory_allocated() // 1024**2} MiB used "
-            f"and {torch.cuda.max_memory_reserved() // 1024**2} MiB reserved)"
-        )
+        if torch.cuda.is_available():
+            mem_stats = (
+                f"GPU memory: {torch.cuda.memory_allocated() // 1024**2} MiB used and "
+                f"{torch.cuda.memory_reserved() // 1024**2} MiB reserved"
+                f" (max over time: {torch.cuda.max_memory_allocated() // 1024**2} MiB used "
+                f"and {torch.cuda.max_memory_reserved() // 1024**2} MiB reserved)"
+            )
+        else:
+            mem_stats = "Running on CPU"
+        session_stats_str = f"live sessions: [{', '.join(live_session_strs)}], {mem_stats}"
         return session_stats_str
 
     def _get_torch_and_gpu_properties(self):
         """Get a string for PyTorch and GPU properties (for logging and debugging)."""
-        torch_and_gpu_str = (
-            f"torch: {torch.__version__} with CUDA arch {torch.cuda.get_arch_list()}, "
-            f"GPU device: {torch.cuda.get_device_properties(torch.cuda.current_device())}"
-        )
+        if torch.cuda.is_available():
+            torch_and_gpu_str = (
+                f"torch: {torch.__version__} with CUDA arch {torch.cuda.get_arch_list()}, "
+                f"GPU device: {torch.cuda.get_device_properties(torch.cuda.current_device())}"
+            )
+        else:
+            torch_and_gpu_str = f"torch: {torch.__version__} (CPU mode)"
         return torch_and_gpu_str
 
     def shutdown(self):

--- a/sam3/model/utils/sam2_utils.py
+++ b/sam3/model/utils/sam2_utils.py
@@ -85,7 +85,7 @@ class AsyncVideoFrameLoader:
         img -= self.img_mean
         img /= self.img_std
         if not self.offload_video_to_cpu:
-            img = img.to(self.compute_device, non_blocking=True)
+            img = img.to(self.compute_device, non_blocking=torch.cuda.is_available())
         self.images[index] = img
         return img
 

--- a/sam3/model/vl_combiner.py
+++ b/sam3/model/vl_combiner.py
@@ -119,8 +119,10 @@ class SAM3VLBackbone(nn.Module):
         return output
 
     def forward_text(
-        self, captions, input_boxes=None, additional_text=None, device="cuda"
+        self, captions, input_boxes=None, additional_text=None, device=None
     ):
+        if device is None:
+            device = "cuda" if torch.cuda.is_available() else "cpu"
         return activation_ckpt_wrapper(self._forward_text_no_ack_ckpt)(
             captions=captions,
             input_boxes=input_boxes,
@@ -134,8 +136,10 @@ class SAM3VLBackbone(nn.Module):
         captions,
         input_boxes=None,
         additional_text=None,
-        device="cuda",
+        device=None,
     ):
+        if device is None:
+            device = "cuda" if torch.cuda.is_available() else "cpu"
         output = {}
 
         # Forward through text_encoder

--- a/sam3/model/vl_combiner.py
+++ b/sam3/model/vl_combiner.py
@@ -11,6 +11,7 @@ import torch.nn as nn
 from torch.nn.attention import sdpa_kernel, SDPBackend
 
 from .act_ckpt_utils import activation_ckpt_wrapper
+from .model_misc import get_default_device
 from .necks import Sam3DualViTDetNeck
 
 
@@ -122,7 +123,7 @@ class SAM3VLBackbone(nn.Module):
         self, captions, input_boxes=None, additional_text=None, device=None
     ):
         if device is None:
-            device = "cuda" if torch.cuda.is_available() else "cpu"
+            device = get_default_device()
         return activation_ckpt_wrapper(self._forward_text_no_ack_ckpt)(
             captions=captions,
             input_boxes=input_boxes,
@@ -139,7 +140,7 @@ class SAM3VLBackbone(nn.Module):
         device=None,
     ):
         if device is None:
-            device = "cuda" if torch.cuda.is_available() else "cpu"
+            device = get_default_device()
         output = {}
 
         # Forward through text_encoder

--- a/sam3/model_builder.py
+++ b/sam3/model_builder.py
@@ -24,6 +24,7 @@ from sam3.model.memory import (
 )
 from sam3.model.model_misc import (
     DotProductScoring,
+    get_default_device,
     MLP,
     MultiheadAttentionWrapper as MultiheadAttention,
     TransformerWrapper,
@@ -558,7 +559,7 @@ def _setup_device_and_mode(model, device, eval_mode):
 
 def build_sam3_image_model(
     bpe_path=None,
-    device="cuda" if torch.cuda.is_available() else "cpu",
+    device=None,
     eval_mode=True,
     checkpoint_path=None,
     load_from_HF=True,
@@ -581,6 +582,8 @@ def build_sam3_image_model(
     Returns:
         A SAM3 image model
     """
+    if device is None:
+        device = get_default_device()
     if bpe_path is None:
         bpe_path = os.path.join(
             os.path.dirname(__file__), "..", "assets", "bpe_simple_vocab_16e6.txt.gz"
@@ -656,7 +659,7 @@ def build_sam3_video_model(
     geo_encoder_use_img_cross_attn: bool = True,
     strict_state_dict_loading: bool = True,
     apply_temporal_disambiguation: bool = True,
-    device="cuda" if torch.cuda.is_available() else "cpu",
+    device=None,
     compile=False,
 ) -> Sam3VideoInferenceWithInstanceInteractivity:
     """
@@ -669,6 +672,8 @@ def build_sam3_video_model(
     Returns:
         Sam3VideoInferenceWithInstanceInteractivity: The instantiated dense tracking model
     """
+    if device is None:
+        device = get_default_device()
     if bpe_path is None:
         bpe_path = os.path.join(
             os.path.dirname(__file__), "..", "assets", "bpe_simple_vocab_16e6.txt.gz"

--- a/sam3/model_builder.py
+++ b/sam3/model_builder.py
@@ -34,7 +34,7 @@ from sam3.model.sam1_task_predictor import SAM3InteractiveImagePredictor
 from sam3.model.sam3_image import Sam3Image, Sam3ImageOnVideoMultiGPU
 from sam3.model.sam3_tracking_predictor import Sam3TrackerPredictor
 from sam3.model.sam3_video_inference import Sam3VideoInferenceWithInstanceInteractivity
-from sam3.model.sam3_video_predictor import Sam3VideoPredictorMultiGPU
+from sam3.model.sam3_video_predictor import Sam3VideoPredictor, Sam3VideoPredictorMultiGPU
 from sam3.model.text_encoder_ve import VETextEncoder
 from sam3.model.tokenizer_ve import SimpleTokenizer
 from sam3.model.vitdet import ViT
@@ -547,8 +547,10 @@ def _load_checkpoint(model, checkpoint_path):
 
 def _setup_device_and_mode(model, device, eval_mode):
     """Setup model device and evaluation mode."""
-    if device == "cuda":
+    if device == "cuda" and torch.cuda.is_available():
         model = model.cuda()
+    elif device != "cpu":
+        model = model.to(device)
     if eval_mode:
         model.eval()
     return model
@@ -788,6 +790,9 @@ def build_sam3_video_model(
 
 
 def build_sam3_video_predictor(*model_args, gpus_to_use=None, **model_kwargs):
+    # Use single-device predictor on CPU, multi-GPU predictor only when CUDA is available
+    if not torch.cuda.is_available():
+        return Sam3VideoPredictor(*model_args, **model_kwargs)
     return Sam3VideoPredictorMultiGPU(
         *model_args, gpus_to_use=gpus_to_use, **model_kwargs
     )

--- a/sam3/perflib/connected_components.py
+++ b/sam3/perflib/connected_components.py
@@ -39,6 +39,13 @@ def connected_components_cpu(input_tensor: torch.Tensor):
         ), "Input tensor must be (B, H, W) or (B, 1, H, W)."
 
     batch_size = input_tensor.shape[0]
+    # Handle empty batch case
+    if batch_size == 0:
+        return (
+            torch.zeros(out_shape, dtype=torch.int64, device=input_tensor.device),
+            torch.zeros(out_shape, dtype=torch.int64, device=input_tensor.device),
+        )
+
     labels_list = []
     counts_list = []
     for b in range(batch_size):


### PR DESCRIPTION
Adds MPS device support for both image and video predictors on Apple Silicon.

Changes:
  - Add get_default_device() utility that detects MPS availability
  - Fix device mismatches (coords cache, freqs_cis cache)
  - Add MPS workaround for complex tensor repeat() in RoPE
  - Make torch._assert_async conditional on CUDA
  - Fix MPS memory leak in video predictor via synchronization points

Performance of the Video predictor:
  - ~3x faster than CPU
  - Runs with ~38GB peak memory. This is due to the way that MPS caches graphs. Before adding the synchronization points, running the video predictor would consume all available memory.