### PR TITLE
fix assert in agent

### DIFF
--- a/sam3/agent/agent_core.py
+++ b/sam3/agent/agent_core.py
@@ -200,10 +200,7 @@ def agent_inference(
     print(f"\n>>> MLLM Response [start]\n{generated_text}\n<<< MLLM Response [end]\n")
     while generated_text is not None:
         save_debug_messages(messages, debug, debug_folder_path, debug_jsonl_path)
-        assert (
-            "<tool>" in generated_text,
-            f"Generated text does not contain <tool> tag: {generated_text}",
-        )
+        assert "<tool>" in generated_text, f"Generated text does not contain <tool> tag: {generated_text}"
         generated_text = generated_text.split("</tool>", 1)[0] + "</tool>"
         tool_call_json_str = (
             generated_text.split("<tool>")[-1]


### PR DESCRIPTION
```
assert (
            "<tool>" in generated_text,
            f"Generated text does not contain <tool> tag: {generated_text}",
        )
```
is always True.