### PR TITLE
Fix: Configure gradient accumulation and chunking collator for stable training

### DIFF
--- a/sam3/train/configs/roboflow_v100/roboflow_v100_full_ft_100_images.yaml
+++ b/sam3/train/configs/roboflow_v100/roboflow_v100_full_ft_100_images.yaml
@@ -227,14 +227,15 @@ scratch:
     dict_key: roboflow100
     with_seg_masks: ${scratch.enable_segmentation} # Note: Set this to true if using segmentation masks!
 
-  gradient_accumulation_steps: 1
-  train_batch_size: 1
+  gradient_accumulation_steps: 16
+  train_batch_size: 16
   collate_fn:
-    _target_: sam3.train.data.collator.collate_fn_api
+    _target_: sam3.train.data.collator.collate_fn_api_with_chunking
     _partial_: true
     repeats: ${scratch.hybrid_repeats}
     dict_key: all
     with_seg_masks: ${scratch.enable_segmentation} # Note: Set this to true if using segmentation masks!
+    num_chunks: ${scratch.gradient_accumulation_steps}
 
 # ============================================================================
 # Trainer Configuration


### PR DESCRIPTION
## Summary
This PR updates the training configuration to enable gradient accumulation. This change stabilizes the training loss and prevents the `ValueError: matrix contains invalid numeric entries` error, which often occurs due to unstable gradients when training with small batch sizes.

## Changes
- Modified [sam3/train/configs/roboflow_v100/roboflow_v100_full_ft_100_images.yaml](cci:7://file:///home/quangnh58/fsoft/sam3/sam3/train/configs/roboflow_v100/roboflow_v100_full_ft_100_images.yaml:0:0-0:0):
    - Increased `gradient_accumulation_steps` to **16**.
    - Increased `train_batch_size` to **16**.
    - Switched [collate_fn](cci:1://file:///home/quangnh58/fsoft/sam3/sam3/train/data/collator.py:135:0-359:5) to `sam3.train.data.collator.collate_fn_api_with_chunking`. This is critical because the trainer expects a list of micro-batches (chunks) when gradient accumulation is enabled, whereas the original [collate_fn_api](cci:1://file:///home/quangnh58/fsoft/sam3/sam3/train/data/collator.py:135:0-359:5) returned a single batch dict, causing an `AssertionError`.
    - Added the `num_chunks` parameter linked to `gradient_accumulation_steps`.

## Verified
Tested locally. The training process is now stable, and the `ValueError` regarding invalid numeric entries in the cost matrix is resolved.