### PR TITLE
Fix: Add pandas to notebooks dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ notebooks = [
     "einops",
     "scikit-image",
     "scikit-learn",
+    "pandas",
 ]
 train = [
     "hydra-core",


### PR DESCRIPTION
## Description
Fixes #151 - Resolves `ModuleNotFoundError: No module named 'pandas'` when running `sam3_image_predictor_example.ipynb`

## Problem
The example notebook `sam3_image_predictor_example.ipynb` requires pandas but it was only listed in the `dev` optional dependencies, not in `notebooks` dependencies. Users installing with `pip install -e ".[notebooks]"` would encounter an import error.

## Solution
Added `pandas` to the `notebooks` optional dependencies in `pyproject.toml`

## Testing
- Verified pandas is now included in notebooks dependencies
- Change is minimal and non-breaking
- Aligns with existing dev dependencies that already include pandas

## Checklist
- [x] Fixes reported issue #151
- [x] Minimal change (single line addition)
- [x] No breaking changes
- [x] Follows existing dependency structure