### PR TITLE
Recognize TIFF images with extension .tif

### DIFF
--- a/sam3/model/io_utils.py
+++ b/sam3/model/io_utils.py
@@ -22,7 +22,7 @@ logger = get_logger(__name__)
 IS_MAIN_PROCESS = os.getenv("IS_MAIN_PROCESS", "1") == "1"
 RANK = int(os.getenv("RANK", "0"))
 
-IMAGE_EXTS = [".jpg", ".jpeg", ".png", ".bmp", ".tiff", ".webp"]
+IMAGE_EXTS = [".jpg", ".jpeg", ".png", ".bmp", ".tif", ".tiff", ".webp"]
 VIDEO_EXTS = [".mp4", ".mov", ".avi", ".mkv", ".webm"]
 
 


### PR DESCRIPTION
This change makes load_resource_as_video_frames() recognize .tif as a file extension for TIFF images.