### PR TITLE
Fix broken file paths of example notebooks

### DIFF
--- a/examples/sam3_image_interactive.ipynb
+++ b/examples/sam3_image_interactive.ipynb
@@ -88,7 +88,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "f84b4ccc-9db2-4d88-ac8f-4c272694d25a",
    "metadata": {},
    "outputs": [],
@@ -96,7 +96,7 @@
     "import sam3\n",
     "from sam3 import build_sam3_image_model\n",
     "import os\n",
-    "sam3_root = os.path.join(os.path.dirname(sam3.__file__), \"..\")\n",
+    "sam3_root = os.path.join(os.path.dirname(sam3.__file__))\n",
     "bpe_path = f\"{sam3_root}/assets/bpe_simple_vocab_16e6.txt.gz\""
    ]
   },

--- a/examples/sam3_image_predictor_example.ipynb
+++ b/examples/sam3_image_predictor_example.ipynb
@@ -58,7 +58,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "output": {
      "id": 1389103906143178,
@@ -79,7 +79,7 @@
     "from sam3.model.sam3_image_processor import Sam3Processor\n",
     "from sam3.visualization_utils import draw_box_on_image, normalize_bbox, plot_results\n",
     "\n",
-    "sam3_root = os.path.join(os.path.dirname(sam3.__file__), \"..\")"
+    "sam3_root = os.path.join(os.path.dirname(sam3.__file__))"
    ]
   },
   {


### PR DESCRIPTION
The location of **bpe_simple_vocab_16e6.txt.gz** has been changed, so I fixed some lines to make the notebooks work.