### PR TITLE
Add the data serialization factor in COCO-JSON-LOADER

### DIFF
--- a/sam3/train/data/coco_json_loaders.py
+++ b/sam3/train/data/coco_json_loaders.py
@@ -6,7 +6,7 @@ from typing import Dict, List, Tuple
 
 import torch
 from pycocotools import mask as mask_util
-
+from .serialization_utils import TorchSerializedList
 
 # ============================================================================
 # Utility Functions
@@ -32,7 +32,7 @@ def convert_boxlist_to_normalized_tensor(box_list, image_width, image_height):
     return boxes
 
 
-def load_coco_and_group_by_image(json_path: str) -> Tuple[List[Dict], Dict[int, str]]:
+def load_coco_and_group_by_image(json_path: str, grouped_serialzation: bool = False) -> Tuple[List[Dict], Dict[int, str]]:
     """
     Load COCO JSON file and group annotations by image.
 
@@ -63,6 +63,9 @@ def load_coco_and_group_by_image(json_path: str) -> Tuple[List[Dict], Dict[int, 
         )
 
     cat_id_to_name = {cat["id"]: cat["name"] for cat in coco["categories"]}
+
+    if grouped_serialzation:
+        grouped = TorchSerializedList(grouped)
 
     return grouped, cat_id_to_name
 
@@ -111,6 +114,7 @@ class COCO_FROM_JSON:
         prompts=None,
         include_negatives=True,
         category_chunk_size=None,
+        grouped_serialzation=False,
     ):
         """
         Initialize the COCO training API.
@@ -121,7 +125,8 @@ class COCO_FROM_JSON:
             include_negatives (bool): Whether to include negative examples (categories with no instances)
         """
         self._raw_data, self._cat_idx_to_text = load_coco_and_group_by_image(
-            annotation_file
+            annotation_file,
+            grouped_serialzation=grouped_serialzation,
         )
         self._sorted_cat_ids = sorted(list(self._cat_idx_to_text.keys()))
         self.prompts = None

--- a/sam3/train/data/serialization_utils.py
+++ b/sam3/train/data/serialization_utils.py
@@ -1,0 +1,91 @@
+"""
+Utility for serializing lists to numpy arrays to avoid copy-on-read overhead.
+
+Based on: https://ppwwyyxx.com/blog/2022/Demystify-RAM-Usage-in-Multiprocess-DataLoader/
+Reference: Detectron2's implementation
+"""
+
+import pickle
+from typing import Any, List
+import numpy as np
+
+
+class NumpySerializedList:
+    """
+    Store a list of Python objects in a serialized numpy array.
+    
+    This class eliminates the "copy-on-read" problem in multiprocessing:
+    - Python objects have refcounts that get updated even on read
+    - Reading objects in forked workers causes copy-on-write to trigger
+    - Each worker ends up copying the entire dataset
+    
+    Solution:
+    - Serialize all objects into a single numpy array (no Python objects)
+    - Numpy arrays have minimal refcounts
+    - Workers share the numpy array without copying
+    - Deserialize on-demand when accessing items
+    
+    Memory savings: ~6x reduction with 4 workers
+    """
+    
+    def __init__(self, lst: List[Any]):
+        """
+        Serialize a list of Python objects.
+        
+        Args:
+            lst: List of Python objects to serialize
+        """
+        # Serialize each item to bytes
+        serialized = [np.frombuffer(pickle.dumps(x), dtype=np.uint8) for x in lst]
+        
+        # Store cumulative lengths for indexing
+        self._addr = np.cumsum([len(x) for x in serialized], dtype=np.int64)
+        
+        # Concatenate all serialized data into single array
+        self._lst = np.concatenate(serialized)
+        
+    def __len__(self):
+        return len(self._addr)
+    
+    def __getitem__(self, idx: int):
+        """
+        Retrieve and deserialize item at index.
+        
+        Args:
+            idx: Index of item to retrieve
+            
+        Returns:
+            Deserialized Python object
+        """
+        start = 0 if idx == 0 else self._addr[idx - 1]
+        end = self._addr[idx]
+        
+        # Use memoryview to avoid copy
+        return pickle.loads(memoryview(self._lst[start:end]))
+
+
+class TorchSerializedList:
+    """
+    Alternative implementation using torch.Tensor for spawn/forkserver mode.
+    
+    torch.Tensor can be pickled more efficiently than numpy in spawn mode.
+    Use this if you're using multiprocessing_context='spawn' or 'forkserver'.
+    """
+    
+    def __init__(self, lst: List[Any]):
+        import torch
+        
+        # Serialize each item
+        serialized = [np.frombuffer(pickle.dumps(x), dtype=np.uint8) for x in lst]
+        
+        # Store as torch tensors
+        self._addr = torch.from_numpy(np.cumsum([len(x) for x in serialized], dtype=np.int64))
+        self._lst = torch.from_numpy(np.concatenate(serialized))
+        
+    def __len__(self):
+        return len(self._addr)
+    
+    def __getitem__(self, idx: int):
+        start = 0 if idx == 0 else self._addr[idx - 1].item()
+        end = self._addr[idx].item()
+        return pickle.loads(bytes(self._lst[start:end].numpy()))


### PR DESCRIPTION
This is for the issue #307 . (Closes #307 )

When I finetuned the sam3 with a large dataset (like larger than 1M 2D images), I faced the memory leak problem in the dataloader.

Then, I followed this post: https://ppwwyyxx.com/blog/2022/Demystify-RAM-Usage-in-Multiprocess-DataLoader/, and it worked well (torch-serialization).

If we want to use the torch-serialization method, we can just adjust the coco_json_loader component in yaml file.
Please just add ```grouped_serialzation: true``` like this:

```yaml
data:
    train:
      _target_: sam3.train.data.torch_dataset.TorchDataset
      dataset:
        _target_: sam3.train.data.sam3_image_dataset.Sam3ImageDataset
        limit_ids: ${biomedseg2d_train.num_images}
        transforms: ${biomedseg2d_train.train_transforms}
        load_segmentation: ${scratch.enable_segmentation}
        coco_json_loader:
          _target_: sam3.train.data.coco_json_loaders.COCO_FROM_JSON
          category_chunk_size: 2
          grouped_serialzation: true # !!!
          _partial_: true
```

