### PR TITLE
docs: Fix typo in README.md - Demonsterates → Demonstrates

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Meng Wang, [Peize Sun](https://peizesun.github.io/),
 
 ![SAM 3 architecture](assets/model_diagram.png?raw=true) SAM 3 is a unified foundation model for promptable segmentation in images and videos. It can detect, segment, and track objects using text or visual prompts such as points, boxes, and masks. Compared to its predecessor [SAM 2](https://github.com/facebookresearch/sam2), SAM 3 introduces the ability to exhaustively segment all instances of an open-vocabulary concept specified by a short text phrase or exemplars. Unlike prior work, SAM 3 can handle a vastly larger set of open-vocabulary prompts. It achieves 75-80% of human performance on our new [SA-CO benchmark](https://github.com/facebookresearch/sam3?tab=readme-ov-file#sa-co-dataset) which contains 270K unique concepts, over 50 times more than existing benchmarks.
 
-This breakthrough is driven by an innovative data engine that has automatically annotated over 4 million unique concepts, creating the largest high-quality open-vocabulary segmentation dataset to date. In addition, SAM 3 introduces a new model architecture featuring a presence token that improves discrimination between closely related text prompts (e.g., “a player in white” vs. “a player in red”), as well as a decoupled detector–tracker design that minimizes task interference and scales efficiently with data.
+This breakthrough is driven by an innovative data engine that has automatically annotated over 4 million unique concepts, creating the largest high-quality open-vocabulary segmentation dataset to date. In addition, SAM 3 introduces a new model architecture featuring a presence token that improves discrimination between closely related text prompts (e.g., "a player in white" vs. "a player in red"), as well as a decoupled detector–tracker design that minimizes task interference and scales efficiently with data.
 
 <p align="center">
   <img src="assets/dog.gif" width=380 />
@@ -159,7 +159,7 @@ various types of prompts:
   further interactive refinements with points.
 - [`sam3_image_batched_inference.ipynb`](examples/sam3_image_batched_inference.ipynb)
   : Demonstrates how to run batched inference with SAM 3 on images.
-- [`sam3_agent.ipynb`](examples/sam3_agent.ipynb): Demonsterates the use of SAM
+- [`sam3_agent.ipynb`](examples/sam3_agent.ipynb): Demonstrates the use of SAM
   3 Agent to segment complex text prompt on images.
 - [`saco_gold_silver_vis_example.ipynb`](examples/saco_gold_silver_vis_example.ipynb)
   : Shows a few examples from SA-Co image evaluation set.


### PR DESCRIPTION
## Description
Fixes a typo in the README.md Examples section

## Problem
The word "Demonsterates" is misspelled in the description of the `sam3_agent.ipynb` notebook.

## Changes
- Fixed typo: `Demonsterates` → `Demonstrates`
- Location: Line 161 in README.md, Examples section

## Impact
- Improves documentation quality
- Corrects spelling error
- Minor text-only change

## Checklist
- [x] Documentation-only change
- [x] No code changes
- [x] Improves readability and professionalism