### PR TITLE
Add agent/system_prompts/*.txt to package-data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,7 @@ include = ["sam3*"]
 exclude = ["build*", "scripts*", "examples*"]
 
 [tool.setuptools.package-data]
-sam3 = ["assets/*.txt.gz"]
+sam3 = ["assets/*.txt.gz", "agent/system_prompts/*.txt"]
 
 [tool.setuptools.dynamic]
 version = {attr = "sam3.__version__"}


### PR DESCRIPTION
## Description
This PR fixes an issue where installing `sam3` via `uv add` or a Git-based
dependency (as shown below) causes a `FileNotFoundError` for the system prompt.

```toml
[project]
dependencies = [
    "sam3 @ git+https://github.com/facebookresearch/sam3.git@5eb25fb54b70ec0cb16f949289053be091e16705",
]
```

## How the issue was discovered

The error occurs when running agent_inference in sam3/agent/agent_core.py
without cloning the repository (i.e., when sam3 is installed as a dependency).

Specifically, a FileNotFoundError is raised at the following line, where the
system prompt file is expected to exist relative to the repository structure:

https://github.com/facebookresearch/sam3/blob/5eb25fb54b70ec0cb16f949289053be091e16705/sam3/agent/agent_core.py#L174