### PR TITLE
feat: allow point-prompt initialization by loading backbone

### DIFF
--- a/sam3/model_builder.py
+++ b/sam3/model_builder.py
@@ -540,6 +540,13 @@ def _load_checkpoint(model, checkpoint_path):
                 if "tracker" in k
             }
         )
+        sam3_image_ckpt.update(
+            {
+                k.replace("detector.backbone.", "inst_interactive_predictor.model.backbone."): v
+                for k, v in ckpt.items()
+                if k.startswith("detector.backbone.")
+            }
+        )
     missing_keys, _ = model.load_state_dict(sam3_image_ckpt, strict=False)
     if len(missing_keys) > 0:
         print(
@@ -615,7 +622,12 @@ def build_sam3_image_model(
     # Create geometry encoder
     input_geometry_encoder = _create_geometry_encoder()
     if enable_inst_interactivity:
-        sam3_pvs_base = build_tracker(apply_temporal_disambiguation=False)
+        # Build with backbone for point-prompting
+        sam3_pvs_base = build_tracker(
+            apply_temporal_disambiguation=False,
+            with_backbone=True,
+            compile_mode=compile_mode,
+        )
         inst_predictor = SAM3InteractiveImagePredictor(sam3_pvs_base)
     else:
         inst_predictor = None


### PR DESCRIPTION
### PR: Enable SAM3 image point-prompting in `sam3_facebook`

**Summary**
- Fixes missing wiring for SAM1-style interactive point prompting by ensuring the interactive tracker is constructed with a visual backbone when `enable_inst_interactivity=True`.

**What changed**
- **`model_builder.py`**
  - Build the interactive tracker with `with_backbone=True` (so `SAM3InteractiveImagePredictor.set_image(*)` can call `forward_image` and compute embeddings).
  - Extend checkpoint loading to also map `detector.backbone.*` weights into `inst_interactive_predictor.model.backbone.*` when instance interactivity is enabled.

**Why**
- In the upstream `sam3` repo, point prompting works because the interactive predictor wraps a tracker that includes a backbone and receives appropriate weights. `sam3_facebook` previously built the tracker without a backbone, preventing feature initialization needed for point prompts.

**Notes**
- No behavior changes to non-interactive inference paths.