### PR TITLE
fix: replace 3 bare excepts with specific exception types

### DIFF
--- a/sam3/model/tokenizer_ve.py
+++ b/sam3/model/tokenizer_ve.py
@@ -186,7 +186,7 @@ class SimpleTokenizer(object):
                     j = word.index(first, i)
                     new_word.extend(word[i:j])
                     i = j
-                except:
+                except ValueError:
                     new_word.extend(word[i:])
                     break
                 if word[i] == first and i < len(word) - 1 and word[i + 1] == second:

--- a/scripts/eval/silver/download_preprocess_nga.py
+++ b/scripts/eval/silver/download_preprocess_nga.py
@@ -52,7 +52,7 @@ def download_item(item, output_folder):
         if response.status_code == 200:
             with open(output_folder / f"{uuid}{EXTENSION}", "wb") as f:
                 f.write(response.content)
-    except:
+    except Exception:
         print("errored", item)
         return
 

--- a/scripts/eval/silver/extract_frames.py
+++ b/scripts/eval/silver/extract_frames.py
@@ -59,7 +59,7 @@ def process_image(args):
         if not is_valid_image(path_frame):
             print(f"Invalid image in {path_frame}")
             to_return = None
-    except:
+    except Exception:
         print(f"Invalid image in {path_frame}")
         to_return = None
     return to_return


### PR DESCRIPTION
## Summary

Replace 3 bare `except:` clauses with specific exception types.

## Changes

- `sam3/model/tokenizer_ve.py`: `except:` → `except ValueError:` for `str.index()` lookup
- `scripts/eval/silver/download_preprocess_nga.py`: `except:` → `except Exception:` for download error handling
- `scripts/eval/silver/extract_frames.py`: `except:` → `except Exception:` for image validation

## Why

Bare `except:` catches `KeyboardInterrupt` and `SystemExit`, which can mask real errors and prevent clean process termination.