### PR TITLE
Fix macOS/CPU compatibility: lazy triton, replace pkg_resources & decord, fix hardcoded device="cuda"

### DIFF
--- a/sam3/model/decoder.py
+++ b/sam3/model/decoder.py
@@ -68,7 +68,8 @@ class TransformerDecoderLayer(nn.Module):
         return tensor if pos is None else tensor + pos
 
     def forward_ffn(self, tgt):
-        with torch.amp.autocast(device_type="cuda", enabled=False):
+        device_type = tgt.device.type if tgt.device.type != "mps" else "cpu"
+        with torch.amp.autocast(device_type=device_type, enabled=False):
             tgt2 = self.linear2(self.dropout3(self.activation(self.linear1(tgt))))
         tgt = tgt + self.dropout4(tgt2)
         tgt = self.norm3(tgt)

--- a/sam3/model/decoder.py
+++ b/sam3/model/decoder.py
@@ -214,6 +214,7 @@ class TransformerDecoder(nn.Module):
         separate_norm_instance: bool = False,
         resolution: Optional[int] = None,
         stride: Optional[int] = None,
+        device: str = "cpu",
     ):
         super().__init__()
         self.d_model = d_model
@@ -275,7 +276,7 @@ class TransformerDecoder(nn.Module):
             if resolution is not None and stride is not None:
                 feat_size = resolution // stride
                 coords_h, coords_w = self._get_coords(
-                    feat_size, feat_size, device="cuda"
+                    feat_size, feat_size, device=device
                 )
                 self.compilable_cord_cache = (coords_h, coords_w)
                 self.compilable_stored_size = (feat_size, feat_size)

--- a/sam3/model/position_encoding.py
+++ b/sam3/model/position_encoding.py
@@ -22,6 +22,7 @@ class PositionEmbeddingSine(nn.Module):
         normalize: bool = True,
         scale: Optional[float] = None,
         precompute_resolution: Optional[int] = None,
+        device: str = "cpu",
     ):
         super().__init__()
         assert num_pos_feats % 2 == 0, "Expecting even model width"
@@ -46,7 +47,7 @@ class PositionEmbeddingSine(nn.Module):
                 (precompute_resolution // 32, precompute_resolution // 32),
             ]
             for size in precompute_sizes:
-                tensors = torch.zeros((1, 1) + size, device="cuda")
+                tensors = torch.zeros((1, 1) + size, device=device)
                 self.forward(tensors)
                 # further clone and detach it in the cache (just to be safe)
                 self.cache[size] = self.cache[size].clone().detach()

--- a/sam3/model/sam3_image_processor.py
+++ b/sam3/model/sam3_image_processor.py
@@ -14,7 +14,7 @@ from torchvision.transforms import v2
 class Sam3Processor:
     """ """
 
-    def __init__(self, model, resolution=1008, device="cpu", confidence_threshold=0.5):
+    def __init__(self, model, resolution=1008, device="cuda", confidence_threshold=0.5):
         self.model = model
         self.resolution = resolution
         self.device = device

--- a/sam3/model/sam3_image_processor.py
+++ b/sam3/model/sam3_image_processor.py
@@ -14,7 +14,7 @@ from torchvision.transforms import v2
 class Sam3Processor:
     """ """
 
-    def __init__(self, model, resolution=1008, device="cuda", confidence_threshold=0.5):
+    def __init__(self, model, resolution=1008, device="cpu", confidence_threshold=0.5):
         self.model = model
         self.resolution = resolution
         self.device = device

--- a/sam3/model/sam3_tracker_utils.py
+++ b/sam3/model/sam3_tracker_utils.py
@@ -6,7 +6,6 @@ import numpy as np
 import torch
 import torch.nn.functional as F
 from numpy.typing import NDArray
-from sam3.model.edt import edt_triton
 
 
 def sample_box_points(
@@ -155,6 +154,9 @@ def sample_one_point_from_error_center(gt_masks, pred_masks, padding=True):
     assert pred_masks.dtype == torch.bool and pred_masks.shape == gt_masks.shape
 
     B, _, H, W = gt_masks.shape
+
+    # Lazy import triton to allow it to run on platforms without it
+    from sam3.model.edt import edt_triton
 
     # false positive region, a new point sampled in this region should have
     # negative label to correct the FP error

--- a/sam3/model_builder.py
+++ b/sam3/model_builder.py
@@ -154,7 +154,7 @@ def _create_transformer_encoder() -> TransformerEncoderFusion:
     return encoder
 
 
-def _create_transformer_decoder() -> TransformerDecoder:
+def _create_transformer_decoder(device="cpu") -> TransformerDecoder:
     """Create transformer decoder with its layer."""
     decoder_layer = TransformerDecoderLayer(
         activation="relu",
@@ -187,6 +187,7 @@ def _create_transformer_decoder() -> TransformerDecoder:
         stride=14,
         use_act_checkpoint=True,
         presence_token=True,
+        device=device,
     )
     return decoder
 
@@ -518,10 +519,12 @@ def _create_vision_backbone(
     return vit_neck
 
 
-def _create_sam3_transformer(has_presence_token: bool = True) -> TransformerWrapper:
+def _create_sam3_transformer(
+    has_presence_token: bool = True, device: str = "cpu"
+) -> TransformerWrapper:
     """Create SAM3 transformer encoder and decoder."""
     encoder: TransformerEncoderFusion = _create_transformer_encoder()
-    decoder: TransformerDecoder = _create_transformer_decoder()
+    decoder: TransformerDecoder = _create_transformer_decoder(device=device)
 
     return TransformerWrapper(encoder=encoder, decoder=decoder, d_model=256)
 
@@ -606,7 +609,7 @@ def build_sam3_image_model(
     backbone = _create_vl_backbone(vision_encoder, text_encoder)
 
     # Create transformer components
-    transformer = _create_sam3_transformer()
+    transformer = _create_sam3_transformer(device=device)
 
     # Create dot product scoring
     dot_prod_scoring = _create_dot_product_scoring()

--- a/sam3/model_builder.py
+++ b/sam3/model_builder.py
@@ -5,7 +5,7 @@
 import os
 from typing import Optional
 
-import pkg_resources
+import importlib.resources
 import torch
 import torch.nn as nn
 from huggingface_hub import hf_hub_download
@@ -583,8 +583,9 @@ def build_sam3_image_model(
         A SAM3 image model
     """
     if bpe_path is None:
-        bpe_path = pkg_resources.resource_filename(
-            "sam3", "assets/bpe_simple_vocab_16e6.txt.gz"
+        bpe_path = str(
+            importlib.resources.files("sam3")
+            / "assets/bpe_simple_vocab_16e6.txt.gz"
         )
 
     # Create visual components
@@ -672,8 +673,9 @@ def build_sam3_video_model(
         Sam3VideoInferenceWithInstanceInteractivity: The instantiated dense tracking model
     """
     if bpe_path is None:
-        bpe_path = pkg_resources.resource_filename(
-            "sam3", "assets/bpe_simple_vocab_16e6.txt.gz"
+        bpe_path = str(
+            importlib.resources.files("sam3")
+            / "assets/bpe_simple_vocab_16e6.txt.gz"
         )
 
     # Build Tracker module

--- a/sam3/model_builder.py
+++ b/sam3/model_builder.py
@@ -693,7 +693,7 @@ def build_sam3_video_model(
     visual_neck = _create_vision_backbone(device=device)
     text_encoder = _create_text_encoder(bpe_path)
     backbone = SAM3VLBackbone(scalp=1, visual=visual_neck, text=text_encoder)
-    transformer = _create_sam3_transformer(has_presence_token=has_presence_token)
+    transformer = _create_sam3_transformer(has_presence_token=has_presence_token, device=device)
     segmentation_head: UniversalSegmentationHead = _create_segmentation_head()
     input_geometry_encoder = _create_geometry_encoder()
 

--- a/sam3/model_builder.py
+++ b/sam3/model_builder.py
@@ -58,7 +58,7 @@ def _setup_tf32() -> None:
 _setup_tf32()
 
 
-def _create_position_encoding(precompute_resolution=None):
+def _create_position_encoding(precompute_resolution=None, device="cpu"):
     """Create position encoding for visual backbone."""
     return PositionEmbeddingSine(
         num_pos_feats=256,
@@ -66,6 +66,7 @@ def _create_position_encoding(precompute_resolution=None):
         scale=None,
         temperature=10000,
         precompute_resolution=precompute_resolution,
+        device=device,
     )
 
 
@@ -499,11 +500,13 @@ def _create_text_encoder(bpe_path: str) -> VETextEncoder:
 
 
 def _create_vision_backbone(
-    compile_mode=None, enable_inst_interactivity=True
+    compile_mode=None, enable_inst_interactivity=True, device="cpu"
 ) -> Sam3DualViTDetNeck:
     """Create SAM3 visual backbone with ViT and neck."""
     # Position encoding
-    position_encoding = _create_position_encoding(precompute_resolution=1008)
+    position_encoding = _create_position_encoding(
+        precompute_resolution=1008, device=device
+    )
     # ViT backbone
     vit_backbone: ViT = _create_vit_backbone(compile_mode=compile_mode)
     vit_neck: Sam3DualViTDetNeck = _create_vit_neck(
@@ -591,7 +594,9 @@ def build_sam3_image_model(
     # Create visual components
     compile_mode = "default" if compile else None
     vision_encoder = _create_vision_backbone(
-        compile_mode=compile_mode, enable_inst_interactivity=enable_inst_interactivity
+        compile_mode=compile_mode,
+        enable_inst_interactivity=enable_inst_interactivity,
+        device=device,
     )
 
     # Create text components
@@ -682,7 +687,7 @@ def build_sam3_video_model(
     tracker = build_tracker(apply_temporal_disambiguation=apply_temporal_disambiguation)
 
     # Build Detector components
-    visual_neck = _create_vision_backbone()
+    visual_neck = _create_vision_backbone(device=device)
     text_encoder = _create_text_encoder(bpe_path)
     backbone = SAM3VLBackbone(scalp=1, visual=visual_neck, text=text_encoder)
     transformer = _create_sam3_transformer(has_presence_token=has_presence_token)

--- a/sam3/train/data/sam3_image_dataset.py
+++ b/sam3/train/data/sam3_image_dataset.py
@@ -17,7 +17,7 @@ from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
 import torch
 import torch.utils.data
 import torchvision
-from decord import cpu, VideoReader
+import av
 from iopath.common.file_io import g_pathmgr
 from PIL import Image as PILImage
 from PIL.Image import DecompressionBombError
@@ -202,17 +202,27 @@ class CustomCocoDetectionAPI(VisionDataset):
             try:
                 if ".mp4" in path and path[-4:] == ".mp4":
                     # Going to load a video frame
-                    video_path, frame = path.split("@")
-                    video = VideoReader(video_path, ctx=cpu(0))
-                    # Convert to PIL image
-                    all_images.append(
-                        (
-                            img_id,
-                            torchvision.transforms.ToPILImage()(
-                                video[int(frame)].asnumpy()
-                            ),
-                        )
+                    video_path, frame_idx = path.split("@")
+                    frame_idx = int(frame_idx)
+                    container = av.open(video_path)
+                    stream = container.streams.video[0]
+                    fps = float(stream.average_rate)
+                    seek_time = frame_idx / fps
+                    container.seek(
+                        int(seek_time * av.time_base), any_frame=False
                     )
+                    pil_frame = None
+                    try:
+                        for packet in container.demux(stream):
+                            for f in packet.decode():
+                                pil_frame = f.to_image().convert("RGB")
+                                break
+                            if pil_frame is not None:
+                                break
+                    finally:
+                        container.close()
+                    # Convert to PIL image
+                    all_images.append((img_id, pil_frame))
                 else:
                     with g_pathmgr.open(path, "rb") as fopen:
                         all_images.append((img_id, PILImage.open(fopen).convert("RGB")))


### PR DESCRIPTION
## Summary

This PR fixes three `ImportError`s that prevent `import sam3` from working on macOS (especially arm64) with modern Python toolchains.

### 1. Replace `pkg_resources` with `importlib.resources` (`sam3/model_builder.py`) ⭐ **unique to this PR**

`pkg_resources` was removed from `setuptools>=71` (released 2024). Using the standard library `importlib.resources.files()` (Python 3.9+) is the recommended replacement and works with all modern setuptools versions.

This fix is **not included in #400** and is required for `import sam3` to work on any environment with `setuptools>=71`, regardless of platform.

### 2. Lazy triton import (`sam3/model/sam3_tracker_utils.py`) ⭐ **unique to this PR**

`from sam3.model.edt import edt_triton` was a module-level import, but `triton` has no macOS wheels (Linux/CUDA only). Moving it inside `sample_one_point_from_error_center()` as a lazy import allows the module to load on any platform. `edt_triton` is only needed when that function is actually called (interactive training), so this change has no effect on normal inference usage.

Fixes: #179

### 3. Replace `decord` with `av` (PyAV) (`sam3/train/data/sam3_image_dataset.py`) ⭐ **unique to this PR**

`decord` has no macOS arm64 wheels. PyAV (`av`) is a well-maintained cross-platform alternative available on all platforms including macOS arm64. (#400 makes `decord` optional but does not provide an alternative implementation.)

### 4. Fix hardcoded `device="cuda"` (`sam3/model/position_encoding.py`, `sam3/model/decoder.py`, `sam3/model_builder.py`)

Removes hardcoded `device="cuda"` in `PositionEmbeddingSine` and `TransformerDecoder` initialization, and propagates the `device` parameter through the model builder chain so that models can be constructed on CPU (and MPS via #400).

> **Note**: This overlaps with #400 which provides a broader MPS support implementation including `grid_sample` CPU fallback, `_assert_async` compatibility, and video/tracking `NotImplementedError`. If #400 is merged first, this hunk can be dropped from this PR.

## Relationship to #400

[#400](https://github.com/facebookresearch/sam3/pull/400) provides comprehensive MPS support (device auto-detection, `grid_sample` fallback, `edt` OpenCV fallback, autocast control, etc.) and has received positive community feedback.

**Suggested merge path** (open to maintainer discretion):
1. Merge #400 to land full MPS support
2. Cherry-pick the `pkg_resources` fix, lazy triton fix, and `decord→PyAV` fix from this PR — or merge this PR after rebasing to drop the now-redundant `device="cuda"` hunks

The three import fixes in this PR are independent of the device/MPS changes and can be taken in any order.

## Notes

These fixes mirror the patches already applied in the [conda-forge sam3-feedstock](https://github.com/conda-forge/sam3-feedstock/tree/main/recipe) (fixes 1 and 3). Fix 2 (`pkg_resources`) is an additional improvement not yet in the feedstock (added in feedstock PR [#7](https://github.com/conda-forge/sam3-feedstock/pull/7)).

## Test

```python
# macOS arm64, Python 3.11, no CUDA
import sam3
from sam3 import build_sam3_image_model
from sam3.model.sam3_image_processor import Sam3Processor
# → succeeds (with expected UserWarning about CUDA not available)
```