### PR TITLE
Disable Triton sigmoid focal loss path when gamma == 0

### DIFF
--- a/sam3/train/loss/loss_fns.py
+++ b/sam3/train/loss/loss_fns.py
@@ -149,6 +149,10 @@ def sigmoid_focal_loss(
     """
     if not (0 <= alpha <= 1) and triton:
         raise RuntimeError(f"Alpha should be in [0,1], got {alpha}")
+    # The Triton backward path is numerically invalid for gamma == 0 because it
+    # computes (1 - p_t) ** (gamma - 1), i.e. an inverse power at zero.
+    if triton and float(gamma) == 0.0:
+        triton = False
     if triton:
         if reduce and not loss_on_multimask:
             loss = triton_sigmoid_focal_loss_reduce(inputs, targets, alpha, gamma)


### PR DESCRIPTION
## Summary

This fixes a numerical issue in the Triton sigmoid focal loss backward path when `gamma == 0`.

In the current Triton kernel, backward computes:

```python
tmp = libdevice.pow(1 - p_t, gamma - 1)
```

When `gamma == 0`, that becomes `(1 - p_t) ** (-1)`. For positive targets with large positive logits, `p_t` approaches `1`, so this term can diverge and produce `inf`/`nan` gradients.

In local reproduction, this surfaced as:

- non-finite matcher inputs
- `SigmoidFocalLossReducedBackward` anomaly-detection failure
- eventual `Loss is nan` during training

## Change

This PR adds a small guard in the focal-loss wrapper:

- if `triton` is enabled and `gamma == 0.0`
- automatically fall back to the existing PyTorch implementation

This keeps Triton enabled for the usual `gamma > 0` case and only bypasses the numerically invalid edge case.

## Why Wrapper Fallback

I chose the wrapper fallback instead of changing the Triton kernel directly because:

- it preserves the exact focal-loss semantics for `gamma == 0`
- it is a minimal, low-risk fix for a clearly defined edge case
- it avoids adding Triton-side branching and special-case backward logic in the custom kernel

If preferred, a follow-up could implement a Triton-side special case for `gamma == 0`, but the wrapper guard is the smallest safe fix.

## Why This Is Safe

- The fallback path already exists and is used by the same wrapper.
- The change is minimal and only affects the `gamma == 0` edge case.
- No behavior changes for the normal Triton-accelerated focal-loss configuration.

## Reproduction

The issue was reproduced from a saved training checkpoint by replaying the real train order (`forward -> backward`) with anomaly detection enabled.

Observed failure mode:

- first bad point at `epoch=1, step=0, chunk=1`
- forward values remained finite
- first non-finite values appeared during backward
- anomaly detection pointed to `SigmoidFocalLossReducedBackward`

For the exact failing `presence` tensors:

- Triton backward produced non-finite gradients
- PyTorch fallback stayed finite

## Validation

After this change:

- the minimal failing replay point no longer produced non-finite gradients
- replay over multiple consecutive training steps completed without non-finite events
- the same training job could be restarted on the patched codebase

## Files

- `sam3/train/loss/loss_fns.py`
