### PR TITLE
Replace deprecated pkg_resources with importlib.resources

### DIFF
--- a/sam3/model_builder.py
+++ b/sam3/model_builder.py
@@ -5,7 +5,7 @@
 import os
 from typing import Optional
 
-import pkg_resources
+from importlib.resources import files  # Modern replacement for pkg_resources
 import torch
 import torch.nn as nn
 from huggingface_hub import hf_hub_download
@@ -583,9 +583,7 @@ def build_sam3_image_model(
         A SAM3 image model
     """
     if bpe_path is None:
-        bpe_path = pkg_resources.resource_filename(
-            "sam3", "assets/bpe_simple_vocab_16e6.txt.gz"
-        )
+        bpe_path = str(files("sam3").joinpath("assets/bpe_simple_vocab_16e6.txt.gz"))
 
     # Create visual components
     compile_mode = "default" if compile else None
@@ -672,9 +670,8 @@ def build_sam3_video_model(
         Sam3VideoInferenceWithInstanceInteractivity: The instantiated dense tracking model
     """
     if bpe_path is None:
-        bpe_path = pkg_resources.resource_filename(
-            "sam3", "assets/bpe_simple_vocab_16e6.txt.gz"
-        )
+        bpe_path = str(files("sam3").joinpath("assets/bpe_simple_vocab_16e6.txt.gz"))
+
 
     # Build Tracker module
     tracker = build_tracker(apply_temporal_disambiguation=apply_temporal_disambiguation)


### PR DESCRIPTION
## Summary

This PR replaces the deprecated `pkg_resources` module with the modern `importlib.resources` API.

## Motivation
- `pkg_resources` is deprecated and was removed from `setuptools>=81.0.0`
- Python 3.12+ users encounter `ModuleNotFoundError: No module named 'pkg_resources'`
- The official recommendation is to use `importlib.resources` (available since Python 3.9)

## Changes
- Replaced `import pkg_resources` with `from importlib.resources import files`
- Updated `build_sam3_image_model()` to use `files("sam3").joinpath(...)` 
- Updated `build_sam3_video_model()` to use `files("sam3").joinpath(...)`

## Testing
- Tested on Python 3.12 with setuptools>=81.0.0
- Verified BPE vocabulary file is correctly located
- All model building functions work as expected

## References
- [setuptools deprecation notice](https://setuptools.pypa.io/en/latest/pkg_resources.html)
- [importlib.resources documentation](https://docs.python.org/3/library/importlib.resources.html)