### PR TITLE
Fix pkg_resources deprecation: migrate to importlib.resources

### DIFF
--- a/sam3/model_builder.py
+++ b/sam3/model_builder.py
@@ -3,9 +3,9 @@
 # pyre-unsafe
 
 import os
+from importlib.resources import files as _importlib_files
 from typing import Optional
 
-import pkg_resources
 import torch
 import torch.nn as nn
 from huggingface_hub import hf_hub_download
@@ -596,8 +596,8 @@ def build_sam3_image_model(
         A SAM3 image model
     """
     if bpe_path is None:
-        bpe_path = pkg_resources.resource_filename(
-            "sam3", "assets/bpe_simple_vocab_16e6.txt.gz"
+        bpe_path = str(
+            _importlib_files("sam3").joinpath("assets/bpe_simple_vocab_16e6.txt.gz")
         )
 
     # Create visual components
@@ -695,8 +695,8 @@ def build_sam3_video_model(
         Sam3VideoInferenceWithInstanceInteractivity: The instantiated dense tracking model
     """
     if bpe_path is None:
-        bpe_path = pkg_resources.resource_filename(
-            "sam3", "assets/bpe_simple_vocab_16e6.txt.gz"
+        bpe_path = str(
+            _importlib_files("sam3").joinpath("assets/bpe_simple_vocab_16e6.txt.gz")
         )
 
     # Build Tracker module
@@ -1105,8 +1105,8 @@ def build_sam3_multiplex_video_predictor(
         Sam3MultiplexVideoPredictor: The fully-initialized predictor
     """
     if bpe_path is None:
-        bpe_path = pkg_resources.resource_filename(
-            "sam3", "assets/bpe_simple_vocab_16e6.txt.gz"
+        bpe_path = str(
+            _importlib_files("sam3").joinpath("assets/bpe_simple_vocab_16e6.txt.gz")
         )
 
     from sam3.model.sam3_multiplex_base import Sam3MultiplexPredictorWrapper


### PR DESCRIPTION
## Summary

`pkg_resources` has been removed in Setuptools ≥ 82.0.0, making the current `sam3/model_builder.py` fail at import time with a hard `ModuleNotFoundError`.

## Root Cause

Three call sites in `model_builder.py` use `pkg_resources.resource_filename()` to locate the bundled BPE tokenizer asset:

```python
import pkg_resources
bpe_path = pkg_resources.resource_filename("sam3", "assets/bpe_simple_vocab_16e6.txt.gz")
```

This pattern appears in `build_sam3_image_model()`, `build_sam3_video_model()`, and `build_sam3_multiplex_video_predictor()`.

## Fix

Replace the deprecated API with the stdlib `importlib.resources.files()` (stable since Python 3.9, no external dependencies):

```python
# Before
import pkg_resources
bpe_path = pkg_resources.resource_filename("sam3", "assets/bpe_simple_vocab_16e6.txt.gz")

# After
from importlib.resources import files as _importlib_files
bpe_path = str(_importlib_files("sam3").joinpath("assets/bpe_simple_vocab_16e6.txt.gz"))
```

`files()` returns a `Traversable`; wrapping with `str()` gives a plain path string compatible with the downstream `SimpleTokenizer(bpe_path=...)` call.

## Compatibility

- Requires Python ≥ 3.9 (already the project minimum)
- No new dependencies added
- Behaviour is identical — resolves the same bundled asset path
- Removes the hard runtime dependency on `setuptools` / `pkg_resources`