### PR TITLE
Add CPU fallback for triton EDT on macOS

### DIFF
--- a/sam3/model/decoder.py
+++ b/sam3/model/decoder.py
@@ -280,7 +280,7 @@ class TransformerDecoder(nn.Module):
             if resolution is not None and stride is not None:
                 feat_size = resolution // stride
                 coords_h, coords_w = self._get_coords(
-                    feat_size, feat_size, device="cuda"
+                    feat_size, feat_size, device="cuda" if torch.cuda.is_available() else "cpu"
                 )
                 self.compilable_cord_cache = (coords_h, coords_w)
                 self.compilable_stored_size = (feat_size, feat_size)

--- a/sam3/model/edt.py
+++ b/sam3/model/edt.py
@@ -5,8 +5,13 @@
 """Triton kernel for euclidean distance transform (EDT)"""
 
 import torch
-import triton
-import triton.language as tl
+
+try:
+    import triton
+    import triton.language as tl
+    _TRITON_AVAILABLE = True
+except ImportError:
+    _TRITON_AVAILABLE = False
 
 """
 Disclaimer: This implementation is not meant to be extremely efficient. A CUDA kernel would likely be more efficient.
@@ -52,68 +57,69 @@ Overall, despite being quite naive, this implementation is roughly 5.5x faster t
 """
 
 
-@triton.jit
-def edt_kernel(inputs_ptr, outputs_ptr, v, z, height, width, horizontal: tl.constexpr):
-    # This is a somewhat verbatim implementation of the efficient 1D EDT algorithm described above
-    # It can be applied horizontally or vertically depending if we're doing the first or second stage.
-    # It's parallelized across batch+row (or batch+col if horizontal=False)
-    # TODO: perhaps the implementation can be revisited if/when local gather/scatter become available in triton
-    batch_id = tl.program_id(axis=0)
-    if horizontal:
-        row_id = tl.program_id(axis=1)
-        block_start = (batch_id * height * width) + row_id * width
-        length = width
-        stride = 1
-    else:
-        col_id = tl.program_id(axis=1)
-        block_start = (batch_id * height * width) + col_id
-        length = height
-        stride = width
+if _TRITON_AVAILABLE:
+    @triton.jit
+    def edt_kernel(inputs_ptr, outputs_ptr, v, z, height, width, horizontal: tl.constexpr):
+        # This is a somewhat verbatim implementation of the efficient 1D EDT algorithm described above
+        # It can be applied horizontally or vertically depending if we're doing the first or second stage.
+        # It's parallelized across batch+row (or batch+col if horizontal=False)
+        # TODO: perhaps the implementation can be revisited if/when local gather/scatter become available in triton
+        batch_id = tl.program_id(axis=0)
+        if horizontal:
+            row_id = tl.program_id(axis=1)
+            block_start = (batch_id * height * width) + row_id * width
+            length = width
+            stride = 1
+        else:
+            col_id = tl.program_id(axis=1)
+            block_start = (batch_id * height * width) + col_id
+            length = height
+            stride = width
 
-    # This will be the index of the right most parabola in the envelope ("the top of the stack")
-    k = 0
-    for q in range(1, length):
-        # Read the function value at the current location. Note that we're doing a singular read, not very efficient
-        cur_input = tl.load(inputs_ptr + block_start + (q * stride))
-        # location of the parabola on top of the stack
-        r = tl.load(v + block_start + (k * stride))
-        # associated boundary
-        z_k = tl.load(z + block_start + (k * stride))
-        # value of the function at the parabola location
-        previous_input = tl.load(inputs_ptr + block_start + (r * stride))
-        # intersection between the two parabolas
-        s = (cur_input - previous_input + q * q - r * r) / (q - r) / 2
-
-        # we'll pop as many parabolas as required
-        while s <= z_k and k - 1 >= 0:
-            k = k - 1
+        # This will be the index of the right most parabola in the envelope ("the top of the stack")
+        k = 0
+        for q in range(1, length):
+            # Read the function value at the current location. Note that we're doing a singular read, not very efficient
+            cur_input = tl.load(inputs_ptr + block_start + (q * stride))
+            # location of the parabola on top of the stack
             r = tl.load(v + block_start + (k * stride))
+            # associated boundary
             z_k = tl.load(z + block_start + (k * stride))
+            # value of the function at the parabola location
             previous_input = tl.load(inputs_ptr + block_start + (r * stride))
+            # intersection between the two parabolas
             s = (cur_input - previous_input + q * q - r * r) / (q - r) / 2
 
-        # Store the new one
-        k = k + 1
-        tl.store(v + block_start + (k * stride), q)
-        tl.store(z + block_start + (k * stride), s)
-        if k + 1 < length:
-            tl.store(z + block_start + ((k + 1) * stride), 1e9)
+            # we'll pop as many parabolas as required
+            while s <= z_k and k - 1 >= 0:
+                k = k - 1
+                r = tl.load(v + block_start + (k * stride))
+                z_k = tl.load(z + block_start + (k * stride))
+                previous_input = tl.load(inputs_ptr + block_start + (r * stride))
+                s = (cur_input - previous_input + q * q - r * r) / (q - r) / 2
 
-    # Last step, we read the envelope to find the min in every location
-    k = 0
-    for q in range(length):
-        while (
-            k + 1 < length
-            and tl.load(
-                z + block_start + ((k + 1) * stride), mask=(k + 1) < length, other=q
-            )
-            < q
-        ):
-            k += 1
-        r = tl.load(v + block_start + (k * stride))
-        d = q - r
-        old_value = tl.load(inputs_ptr + block_start + (r * stride))
-        tl.store(outputs_ptr + block_start + (q * stride), old_value + d * d)
+            # Store the new one
+            k = k + 1
+            tl.store(v + block_start + (k * stride), q)
+            tl.store(z + block_start + (k * stride), s)
+            if k + 1 < length:
+                tl.store(z + block_start + ((k + 1) * stride), 1e9)
+
+        # Last step, we read the envelope to find the min in every location
+        k = 0
+        for q in range(length):
+            while (
+                k + 1 < length
+                and tl.load(
+                    z + block_start + ((k + 1) * stride), mask=(k + 1) < length, other=q
+                )
+                < q
+            ):
+                k += 1
+            r = tl.load(v + block_start + (k * stride))
+            d = q - r
+            old_value = tl.load(inputs_ptr + block_start + (r * stride))
+            tl.store(outputs_ptr + block_start + (q * stride), old_value + d * d)
 
 
 def edt_triton(data: torch.Tensor):
@@ -128,8 +134,20 @@ def edt_triton(data: torch.Tensor):
         It should be equivalent to a batched version of cv2.distanceTransform(input, cv2.DIST_L2, 0)
     """
     assert data.dim() == 3
-    assert data.is_cuda
     B, H, W = data.shape
+
+    if not _TRITON_AVAILABLE or not data.is_cuda:
+        # CPU fallback using OpenCV
+        import cv2
+        import numpy as np
+        result = torch.zeros(B, H, W, dtype=torch.float32)
+        data_np = data.cpu().numpy().astype(np.uint8)
+        for i in range(B):
+            result[i] = torch.from_numpy(
+                cv2.distanceTransform(data_np[i], cv2.DIST_L2, 0)
+            )
+        return result.to(data.device)
+
     data = data.contiguous()
 
     # Allocate the "function" tensor. Implicitly the function is 0 if data[i,j]==0 else +infinity

--- a/sam3/model/geometry_encoders.py
+++ b/sam3/model/geometry_encoders.py
@@ -645,7 +645,11 @@ class SequenceGeometryEncoder(nn.Module):
             # We need to denormalize, and convert to [x, y, x, y]
             boxes_xyxy = box_cxcywh_to_xyxy(boxes)
             scale = torch.tensor([W, H, W, H], dtype=boxes_xyxy.dtype)
-            scale = scale.pin_memory().to(device=boxes_xyxy.device, non_blocking=True)
+            scale = (
+                scale.pin_memory().to(device=boxes_xyxy.device, non_blocking=True)
+                if torch.cuda.is_available()
+                else scale.to(device=boxes_xyxy.device)
+            )
             scale = scale.view(1, 1, 4)
             boxes_xyxy = boxes_xyxy * scale
             sampled = torchvision.ops.roi_align(

--- a/sam3/model/io_utils.py
+++ b/sam3/model/io_utils.py
@@ -19,6 +19,8 @@ from tqdm import tqdm
 
 logger = get_logger(__name__)
 
+_DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
+
 IS_MAIN_PROCESS = os.getenv("IS_MAIN_PROCESS", "1") == "1"
 RANK = int(os.getenv("RANK", "0"))
 
@@ -63,7 +65,7 @@ def load_resource_as_video_frames(
             images.append(img)
         images = torch.stack(images)
         if not offload_video_to_cpu:
-            images = images.cuda()
+            images = images.to(_DEVICE)
         return images, orig_height, orig_width
 
     is_image = (
@@ -104,9 +106,9 @@ def load_image_as_single_frame_video(
     img_mean = torch.tensor(img_mean, dtype=torch.float16)[:, None, None]
     img_std = torch.tensor(img_std, dtype=torch.float16)[:, None, None]
     if not offload_video_to_cpu:
-        images = images.cuda()
-        img_mean = img_mean.cuda()
-        img_std = img_std.cuda()
+        images = images.to(_DEVICE)
+        img_mean = img_mean.to(_DEVICE)
+        img_std = img_std.to(_DEVICE)
     # normalize by mean and std
     images -= img_mean
     images /= img_std
@@ -208,9 +210,9 @@ def load_video_frames_from_image_folder(
     ):
         images[n], video_height, video_width = _load_img_as_tensor(img_path, image_size)
     if not offload_video_to_cpu:
-        images = images.cuda()
-        img_mean = img_mean.cuda()
-        img_std = img_std.cuda()
+        images = images.to(_DEVICE)
+        img_mean = img_mean.to(_DEVICE)
+        img_std = img_std.to(_DEVICE)
     # normalize by mean and std
     images -= img_mean
     images /= img_std
@@ -320,9 +322,9 @@ def load_video_frames_from_video_file_using_cv2(
     img_mean = torch.tensor(img_mean, dtype=torch.float16).view(1, 3, 1, 1)
     img_std = torch.tensor(img_std, dtype=torch.float16).view(1, 3, 1, 1)
     if not offload_video_to_cpu:
-        video_tensor = video_tensor.cuda()
-        img_mean = img_mean.cuda()
-        img_std = img_std.cuda()
+        video_tensor = video_tensor.to(_DEVICE)
+        img_mean = img_mean.to(_DEVICE)
+        img_std = img_std.to(_DEVICE)
     # normalize by mean and std
     video_tensor -= img_mean
     video_tensor /= img_std
@@ -339,7 +341,7 @@ def load_dummy_video(image_size, offload_video_to_cpu, num_frames=60, do_zeros=F
     else:
         images = torch.zeros(num_frames, 3, image_size, image_size, dtype=torch.float16)
     if not offload_video_to_cpu:
-        images = images.cuda()
+        images = images.to(_DEVICE)
     return images, video_height, video_width
 
 
@@ -408,7 +410,7 @@ class AsyncImageFrameLoader:
         img -= self.img_mean
         img /= self.img_std
         if not self.offload_video_to_cpu:
-            img = img.cuda()
+            img = img.to(_DEVICE)
         self.images[index] = img
         return img
 

--- a/sam3/model/io_utils.py
+++ b/sam3/model/io_utils.py
@@ -19,7 +19,7 @@ from tqdm import tqdm
 
 logger = get_logger(__name__)
 
-_DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
+_DEVICE = "cuda" if torch.cuda.is_available() else "mps" if torch.backends.mps.is_available() else "cpu"
 
 IS_MAIN_PROCESS = os.getenv("IS_MAIN_PROCESS", "1") == "1"
 RANK = int(os.getenv("RANK", "0"))

--- a/sam3/model/io_utils.py
+++ b/sam3/model/io_utils.py
@@ -19,8 +19,8 @@ from tqdm import tqdm
 
 logger = get_logger(__name__)
 
-_DEVICE = "cuda" if torch.cuda.is_available() else "mps" if torch.backends.mps.is_available() else "cpu"
-# MPS doesn't support bfloat16 accumulation; use float32 on non-CUDA devices.
+# MPS is excluded: sam3 uses bfloat16 ops incompatible with MPS matmul accumulation.
+_DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
 _DTYPE = torch.float16 if torch.cuda.is_available() else torch.float32
 
 IS_MAIN_PROCESS = os.getenv("IS_MAIN_PROCESS", "1") == "1"

--- a/sam3/model/io_utils.py
+++ b/sam3/model/io_utils.py
@@ -20,6 +20,8 @@ from tqdm import tqdm
 logger = get_logger(__name__)
 
 _DEVICE = "cuda" if torch.cuda.is_available() else "mps" if torch.backends.mps.is_available() else "cpu"
+# MPS doesn't support bfloat16 accumulation; use float32 on non-CUDA devices.
+_DTYPE = torch.float16 if torch.cuda.is_available() else torch.float32
 
 IS_MAIN_PROCESS = os.getenv("IS_MAIN_PROCESS", "1") == "1"
 RANK = int(os.getenv("RANK", "0"))
@@ -42,8 +44,8 @@ def load_resource_as_video_frames(
     Alternatively, if input is a list of PIL images, convert its format
     """
     if isinstance(resource_path, list):
-        img_mean = torch.tensor(img_mean, dtype=torch.float16)[:, None, None]
-        img_std = torch.tensor(img_std, dtype=torch.float16)[:, None, None]
+        img_mean = torch.tensor(img_mean, dtype=_DTYPE)[:, None, None]
+        img_std = torch.tensor(img_std, dtype=_DTYPE)[:, None, None]
         assert all(isinstance(img_pil, Image.Image) for img_pil in resource_path)
         assert len(resource_path) is not None
         orig_height, orig_width = resource_path[0].size
@@ -58,7 +60,7 @@ def load_resource_as_video_frames(
             img_np = img_np / 255.0
             img = torch.from_numpy(img_np).permute(2, 0, 1)
             # float16 precision should be sufficient for image tensor storage
-            img = img.to(dtype=torch.float16)
+            img = img.to(dtype=_DTYPE)
             # normalize by mean and std
             img -= img_mean
             img /= img_std
@@ -101,10 +103,10 @@ def load_image_as_single_frame_video(
 ):
     """Load an image as a single-frame video."""
     images, image_height, image_width = _load_img_as_tensor(image_path, image_size)
-    images = images.unsqueeze(0).half()
+    images = images.unsqueeze(0).to(_DTYPE)
 
-    img_mean = torch.tensor(img_mean, dtype=torch.float16)[:, None, None]
-    img_std = torch.tensor(img_std, dtype=torch.float16)[:, None, None]
+    img_mean = torch.tensor(img_mean, dtype=_DTYPE)[:, None, None]
+    img_std = torch.tensor(img_std, dtype=_DTYPE)[:, None, None]
     if not offload_video_to_cpu:
         images = images.to(_DEVICE)
         img_mean = img_mean.to(_DEVICE)
@@ -193,8 +195,8 @@ def load_video_frames_from_image_folder(
     if num_frames == 0:
         raise RuntimeError(f"no images found in {image_folder}")
     img_paths = [os.path.join(image_folder, frame_name) for frame_name in frame_names]
-    img_mean = torch.tensor(img_mean, dtype=torch.float16)[:, None, None]
-    img_std = torch.tensor(img_std, dtype=torch.float16)[:, None, None]
+    img_mean = torch.tensor(img_mean, dtype=_DTYPE)[:, None, None]
+    img_std = torch.tensor(img_std, dtype=_DTYPE)[:, None, None]
 
     if async_loading_frames:
         lazy_images = AsyncImageFrameLoader(
@@ -203,7 +205,7 @@ def load_video_frames_from_image_folder(
         return lazy_images, lazy_images.video_height, lazy_images.video_width
 
     # float16 precision should be sufficient for image tensor storage
-    images = torch.zeros(num_frames, 3, image_size, image_size, dtype=torch.float16)
+    images = torch.zeros(num_frames, 3, image_size, image_size, dtype=_DTYPE)
     video_height, video_width = None, None
     for n, img_path in enumerate(
         tqdm(img_paths, desc=f"frame loading (image folder) [rank={RANK}]")
@@ -319,8 +321,8 @@ def load_video_frames_from_video_file_using_cv2(
     frames_np = np.stack(frames, axis=0).astype(np.float32)  # (T, H, W, C)
     video_tensor = torch.from_numpy(frames_np).permute(0, 3, 1, 2)  # (T, C, H, W)
 
-    img_mean = torch.tensor(img_mean, dtype=torch.float16).view(1, 3, 1, 1)
-    img_std = torch.tensor(img_std, dtype=torch.float16).view(1, 3, 1, 1)
+    img_mean = torch.tensor(img_mean, dtype=_DTYPE).view(1, 3, 1, 1)
+    img_std = torch.tensor(img_std, dtype=_DTYPE).view(1, 3, 1, 1)
     if not offload_video_to_cpu:
         video_tensor = video_tensor.to(_DEVICE)
         img_mean = img_mean.to(_DEVICE)
@@ -337,9 +339,9 @@ def load_dummy_video(image_size, offload_video_to_cpu, num_frames=60, do_zeros=F
     """
     video_height, video_width = 480, 640  # dummy original video sizes
     if not do_zeros:
-        images = torch.randn(num_frames, 3, image_size, image_size, dtype=torch.float16)
+        images = torch.randn(num_frames, 3, image_size, image_size, dtype=_DTYPE)
     else:
-        images = torch.zeros(num_frames, 3, image_size, image_size, dtype=torch.float16)
+        images = torch.zeros(num_frames, 3, image_size, image_size, dtype=_DTYPE)
     if not offload_video_to_cpu:
         images = images.to(_DEVICE)
     return images, video_height, video_width
@@ -405,7 +407,7 @@ class AsyncImageFrameLoader:
         self.video_height = video_height
         self.video_width = video_width
         # float16 precision should be sufficient for image tensor storage
-        img = img.to(dtype=torch.float16)
+        img = img.to(dtype=_DTYPE)
         # normalize by mean and std
         img -= self.img_mean
         img /= self.img_std
@@ -537,10 +539,10 @@ class AsyncVideoFileLoaderWithTorchCodec:
         self.image_size = image_size
         self.offload_video_to_cpu = offload_video_to_cpu
         if not isinstance(img_mean, torch.Tensor):
-            img_mean = torch.tensor(img_mean, dtype=torch.float16)[:, None, None]
+            img_mean = torch.tensor(img_mean, dtype=_DTYPE)[:, None, None]
         self.img_mean = img_mean
         if not isinstance(img_std, torch.Tensor):
-            img_std = torch.tensor(img_std, dtype=torch.float16)[:, None, None]
+            img_std = torch.tensor(img_std, dtype=_DTYPE)[:, None, None]
         self.img_std = img_std
 
         if gpu_acceleration:
@@ -569,7 +571,7 @@ class AsyncVideoFileLoaderWithTorchCodec:
             3,
             self.image_size,
             self.image_size,
-            dtype=torch.float16,
+            dtype=_DTYPE,
             device=self.out_device,
         )
         # catch and raise any exceptions in the async loading thread
@@ -671,7 +673,7 @@ class AsyncVideoFileLoaderWithTorchCodec:
             align_corners=False,
         )[0]
         # float16 precision should be sufficient for image tensor storage
-        frame_resized = frame_resized.half()  # uint8 -> float16
+        frame_resized = frame_resized.to(_DTYPE)  # uint8 -> float16
         frame_resized /= 255
         frame_resized -= self.img_mean
         frame_resized /= self.img_std

--- a/sam3/model/position_encoding.py
+++ b/sam3/model/position_encoding.py
@@ -52,7 +52,7 @@ class PositionEmbeddingSine(nn.Module):
                 (precompute_resolution // 32, precompute_resolution // 32),
             ]
             for size in precompute_sizes:
-                tensors = torch.zeros((1, 1) + size, device="cuda")
+                tensors = torch.zeros((1, 1) + size, device="cuda" if torch.cuda.is_available() else "cpu")
                 self.forward(tensors)
                 # further clone and detach it in the cache (just to be safe)
                 self.cache[size] = self.cache[size].clone().detach()

--- a/sam3/model/sam3_image.py
+++ b/sam3/model/sam3_image.py
@@ -861,7 +861,7 @@ class Sam3ImageOnVideoMultiGPU(Sam3Image):
             assert len(feats["backbone_fpn"]) == 3  # SAM2 backbone always have 3 levels
             # cast the SAM2 backbone features to bfloat16 for all-gather (this is usually
             # a no-op, SAM2 backbone features are likely already in bfloat16 due to AMP)
-            backbone_fpn_bf16 = [x.to(torch.bfloat16) for x in feats["backbone_fpn"]]
+            backbone_fpn_bf16 = [x.to(torch.bfloat16) if torch.cuda.is_available() else x for x in feats["backbone_fpn"]]
             fpn0, fpn_handle0 = self._gather_tensor(backbone_fpn_bf16[0])
             fpn1, fpn_handle1 = self._gather_tensor(backbone_fpn_bf16[1])
             fpn2, fpn_handle2 = self._gather_tensor(backbone_fpn_bf16[2])

--- a/sam3/model/sam3_multiplex_base.py
+++ b/sam3/model/sam3_multiplex_base.py
@@ -2236,9 +2236,13 @@ class Sam3MultiplexBase(Sam3VideoBase):
         # Suppress if: keep_alive <= 0 AND not hotstart-only mode AND not removed
         suppress_by_unmatch = (
             (trk_keep_alive <= 0)
-            & torch.tensor(not self.suppress_unmatched_only_within_hotstart)
-            .pin_memory()
-            .to(device=device, non_blocking=True)
+            & (
+                torch.tensor(not self.suppress_unmatched_only_within_hotstart)
+                .pin_memory()
+                .to(device=device, non_blocking=True)
+                if torch.cuda.is_available()
+                else torch.tensor(not self.suppress_unmatched_only_within_hotstart).to(device=device)
+            )
             & ~removed_mask
             & ~remove_by_unmatch
         )
@@ -2504,6 +2508,8 @@ class Sam3MultiplexBase(Sam3VideoBase):
                     torch.tensor(object_idx_assignment[state_i])
                     .pin_memory()
                     .to(device=high_res_masks.device, non_blocking=True)
+                    if torch.cuda.is_available()
+                    else torch.tensor(object_idx_assignment[state_i]).to(device=high_res_masks.device)
                 )
                 local_high_res_masks = high_res_masks[local_idx]
                 local_object_score_logits = object_score_logits[local_idx]

--- a/sam3/model/sam3_multiplex_detector.py
+++ b/sam3/model/sam3_multiplex_detector.py
@@ -546,7 +546,7 @@ class Sam3MultiplexDetector(Sam3MultiplexImageBase):
                 # cast the SAM2 backbone features to bfloat16 for all-gather (this is usually
                 # a no-op, SAM2 backbone features are likely already in bfloat16 due to AMP)
                 inte_backbone_fpn_bf16 = [
-                    x.to(torch.bfloat16) for x in inte_feats["backbone_fpn"]
+                    x.to(torch.bfloat16) if torch.cuda.is_available() else x for x in inte_feats["backbone_fpn"]
                 ]
                 inte_fpn0, inte_fpn_handle0 = self._gather_tensor(
                     inte_backbone_fpn_bf16[0].tensors
@@ -566,7 +566,7 @@ class Sam3MultiplexDetector(Sam3MultiplexImageBase):
             assert all(x.mask is None for x in feats["backbone_fpn"])
             # cast the SAM2 backbone features to bfloat16 for all-gather (this is usually
             # a no-op, SAM2 backbone features are likely already in bfloat16 due to AMP)
-            backbone_fpn_bf16 = [x.to(torch.bfloat16) for x in feats["backbone_fpn"]]
+            backbone_fpn_bf16 = [x.to(torch.bfloat16) if torch.cuda.is_available() else x for x in feats["backbone_fpn"]]
             fpn0, fpn_handle0 = self._gather_tensor(backbone_fpn_bf16[0].tensors)
             fpn1, fpn_handle1 = self._gather_tensor(backbone_fpn_bf16[1].tensors)
             fpn2, fpn_handle2 = self._gather_tensor(backbone_fpn_bf16[2].tensors)

--- a/sam3/model/sam3_multiplex_tracking.py
+++ b/sam3/model/sam3_multiplex_tracking.py
@@ -715,8 +715,10 @@ class Sam3MultiplexTracking(Sam3MultiplexBase):
 
             # slice those valid entries from the original outputs
             keep_idx = torch.nonzero(keep, as_tuple=True)[0]
-            keep_idx_gpu = keep_idx.pin_memory().to(
-                device=out_binary_masks.device, non_blocking=True
+            keep_idx_gpu = (
+                keep_idx.pin_memory().to(device=out_binary_masks.device, non_blocking=True)
+                if torch.cuda.is_available()
+                else keep_idx.to(device=out_binary_masks.device)
             )
 
             out_obj_ids = torch.index_select(out_obj_ids, 0, keep_idx)

--- a/sam3/model/sam3_tracker_base.py
+++ b/sam3/model/sam3_tracker_base.py
@@ -657,14 +657,14 @@ class Sam3TrackerBase(torch.nn.Module):
                     continue  # skip padding frames
                 # "maskmem_features" might have been offloaded to CPU in demo use cases,
                 # so we load it back to GPU (it's a no-op if it's already on GPU).
-                feats = prev["maskmem_features"].cuda(non_blocking=True)
+                feats = prev["maskmem_features"].to(device, non_blocking=True)
                 seq_len = feats.shape[-2] * feats.shape[-1]
                 to_cat_prompt.append(feats.flatten(2).permute(2, 0, 1))
                 to_cat_prompt_mask.append(
                     torch.zeros(B, seq_len, device=device, dtype=bool)
                 )
                 # Spatial positional encoding (it might have been offloaded to CPU in eval)
-                maskmem_enc = prev["maskmem_pos_enc"][-1].cuda()
+                maskmem_enc = prev["maskmem_pos_enc"][-1].to(device)
                 maskmem_enc = maskmem_enc.flatten(2).permute(2, 0, 1)
 
                 if (

--- a/sam3/model/sam3_tracker_base.py
+++ b/sam3/model/sam3_tracker_base.py
@@ -164,7 +164,11 @@ class Sam3TrackerBase(torch.nn.Module):
 
         t_diff_max = max_abs_pos - 1 if max_abs_pos is not None else 1
         pos_enc = (
-            torch.tensor(rel_pos_list).pin_memory().to(device=device, non_blocking=True)
+            (
+                torch.tensor(rel_pos_list).pin_memory().to(device=device, non_blocking=True)
+                if torch.cuda.is_available()
+                else torch.tensor(rel_pos_list).to(device=device)
+            )
             / t_diff_max
         )
         tpos_dim = self.hidden_dim

--- a/sam3/model/sam3_tracking_predictor.py
+++ b/sam3/model/sam3_tracking_predictor.py
@@ -304,7 +304,7 @@ class Sam3TrackerPredictor(Sam3TrackerBase):
                     prev_out = obj_output_dict["non_cond_frame_outputs"].get(frame_idx)
 
             if prev_out is not None and prev_out["pred_masks"] is not None:
-                prev_sam_mask_logits = prev_out["pred_masks"].cuda(non_blocking=True)
+                prev_sam_mask_logits = prev_out["pred_masks"].to(inference_state["device"], non_blocking=True)
                 # Clamp the scale of prev_sam_mask_logits to avoid rare numerical issues.
                 prev_sam_mask_logits = torch.clamp(prev_sam_mask_logits, -32.0, 32.0)
         current_out, _ = self._run_single_frame_inference(
@@ -1025,7 +1025,7 @@ class Sam3TrackerPredictor(Sam3TrackerBase):
                 )
             else:
                 # Cache miss -- we will run inference on a single image
-                image = inference_state["images"][frame_idx].cuda().float().unsqueeze(0)
+                image = inference_state["images"][frame_idx].to(inference_state["device"]).float().unsqueeze(0)
                 backbone_out = self.forward_image(image)
                 # Cache the most recent frame's feature (for repeated interactions with
                 # a frame; we can use an LRU cache for more frames in the future).

--- a/sam3/model/sam3_tracking_predictor.py
+++ b/sam3/model/sam3_tracking_predictor.py
@@ -47,8 +47,11 @@ class Sam3TrackerPredictor(Sam3TrackerBase):
         self.max_point_num_in_prompt_enc = max_point_num_in_prompt_enc
         self.non_overlap_masks_for_output = non_overlap_masks_for_output
 
-        self.bf16_context = torch.autocast(device_type="cuda", dtype=torch.bfloat16)
-        self.bf16_context.__enter__()  # keep using for the entire model process
+        if torch.cuda.is_available():
+            self.bf16_context = torch.autocast(device_type="cuda", dtype=torch.bfloat16)
+            self.bf16_context.__enter__()  # keep using for the entire model process
+        else:
+            self.bf16_context = None
 
         self.iter_use_prev_mask_pred = True
         self.add_all_frames_to_correct_as_cond = True
@@ -76,7 +79,7 @@ class Sam3TrackerPredictor(Sam3TrackerBase):
         # and from 24 to 21 when tracking two objects)
         inference_state["offload_state_to_cpu"] = offload_state_to_cpu
         inference_state["device"] = self.device
-        if offload_state_to_cpu:
+        if offload_state_to_cpu or not torch.cuda.is_available():
             inference_state["storage_device"] = torch.device("cpu")
         else:
             inference_state["storage_device"] = torch.device("cuda")

--- a/sam3/model/sam3_tracking_predictor.py
+++ b/sam3/model/sam3_tracking_predictor.py
@@ -1094,7 +1094,8 @@ class Sam3TrackerPredictor(Sam3TrackerBase):
         storage_device = inference_state["storage_device"]
         maskmem_features = current_out["maskmem_features"]
         if maskmem_features is not None:
-            maskmem_features = maskmem_features.to(torch.bfloat16)
+            if torch.cuda.is_available():
+                maskmem_features = maskmem_features.to(torch.bfloat16)
             maskmem_features = maskmem_features.to(storage_device, non_blocking=True)
         pred_masks_gpu = current_out["pred_masks"]
         pred_masks = pred_masks_gpu.to(storage_device, non_blocking=True)
@@ -1145,7 +1146,8 @@ class Sam3TrackerPredictor(Sam3TrackerBase):
 
         # optionally offload the output to CPU memory to save GPU space
         storage_device = inference_state["storage_device"]
-        maskmem_features = maskmem_features.to(torch.bfloat16)
+        if torch.cuda.is_available():
+            maskmem_features = maskmem_features.to(torch.bfloat16)
         maskmem_features = maskmem_features.to(storage_device, non_blocking=True)
         # "maskmem_pos_enc" is the same across frames, so we only need to store one copy of it
         maskmem_pos_enc = self._get_maskmem_pos_enc(

--- a/sam3/model/sam3_video_inference.py
+++ b/sam3/model/sam3_video_inference.py
@@ -478,8 +478,10 @@ class Sam3VideoInference(Sam3VideoBase):
 
             # slice those valid entries from the original outputs
             keep_idx = torch.nonzero(keep, as_tuple=True)[0]
-            keep_idx_gpu = keep_idx.pin_memory().to(
-                device=out_binary_masks.device, non_blocking=True
+            keep_idx_gpu = (
+                keep_idx.pin_memory().to(device=out_binary_masks.device, non_blocking=True)
+                if torch.cuda.is_available()
+                else keep_idx.to(device=out_binary_masks.device)
             )
 
             out_obj_ids = torch.index_select(out_obj_ids, 0, keep_idx)

--- a/sam3/model/video_tracking_multiplex.py
+++ b/sam3/model/video_tracking_multiplex.py
@@ -534,7 +534,11 @@ class VideoTrackingMultiplex(nn.Module):
 
         t_diff_max = max_abs_pos - 1 if max_abs_pos is not None else 1
         pos_enc = (
-            torch.tensor(rel_pos_list).pin_memory().to(device=device, non_blocking=True)
+            (
+                torch.tensor(rel_pos_list).pin_memory().to(device=device, non_blocking=True)
+                if torch.cuda.is_available()
+                else torch.tensor(rel_pos_list).to(device=device)
+            )
             / t_diff_max
         )
         if self.sincos_tpos_enc:

--- a/sam3/model/vl_combiner.py
+++ b/sam3/model/vl_combiner.py
@@ -121,7 +121,7 @@ class SAM3VLBackbone(nn.Module):
         return output
 
     def forward_text(
-        self, captions, input_boxes=None, additional_text=None, device="cuda"
+        self, captions, input_boxes=None, additional_text=None, device="cuda" if torch.cuda.is_available() else "cpu"
     ):
         return activation_ckpt_wrapper(self._forward_text_no_ack_ckpt)(
             captions=captions,
@@ -136,7 +136,7 @@ class SAM3VLBackbone(nn.Module):
         captions,
         input_boxes=None,
         additional_text=None,
-        device="cuda",
+        device="cuda" if torch.cuda.is_available() else "cpu",
     ):
         output = {}
 
@@ -324,7 +324,7 @@ class VisionOnly(nn.Module):
         captions,
         input_boxes=None,
         additional_text=None,
-        device="cuda",
+        device="cuda" if torch.cuda.is_available() else "cpu",
     ):
         bs = len(captions)
         output = {

--- a/sam3/perflib/connected_components.py
+++ b/sam3/perflib/connected_components.py
@@ -41,6 +41,10 @@ def connected_components_cpu(input_tensor: torch.Tensor):
         )
 
     batch_size = input_tensor.shape[0]
+    if batch_size == 0:
+        empty = torch.zeros(out_shape, dtype=torch.long, device=input_tensor.device)
+        return empty, empty
+
     labels_list = []
     counts_list = []
     for b in range(batch_size):

--- a/sam3/perflib/fused.py
+++ b/sam3/perflib/fused.py
@@ -16,6 +16,19 @@ def addmm_act(activation, linear, mat1):
     mat1 = mat1.to(torch.bfloat16)
     mat2 = mat2.to(torch.bfloat16)
     mat1_flat = mat1.view(-1, mat1.shape[-1])
+
+    if not torch.cuda.is_available():
+        # aten::_addmm_activation is a CUDA-only fused kernel; fall back to
+        # standard ops on CPU / MPS.
+        y = mat1_flat @ mat2.t() + self
+        if activation in [torch.nn.functional.relu, torch.nn.ReLU]:
+            y = torch.relu(y)
+        elif activation in [torch.nn.functional.gelu, torch.nn.GELU]:
+            y = torch.nn.functional.gelu(y)
+        else:
+            raise ValueError(f"Unexpected activation {activation}")
+        return y.view(mat1.shape[:-1] + (y.shape[-1],))
+
     if activation in [torch.nn.functional.relu, torch.nn.ReLU]:
         y = addmm_act_op(self, mat1_flat, mat2.t(), beta=1, alpha=1, use_gelu=False)
         return y.view(mat1.shape[:-1] + (y.shape[-1],))

--- a/sam3/perflib/fused.py
+++ b/sam3/perflib/fused.py
@@ -10,20 +10,18 @@ addmm_act_op = torch.ops.aten._addmm_activation
 def addmm_act(activation, linear, mat1):
     if torch.is_grad_enabled():
         raise ValueError("Expected grad to be disabled.")
-    self = linear.bias.detach()
-    mat2 = linear.weight.detach()
-    self = self.to(torch.bfloat16)
-    mat1 = mat1.to(torch.bfloat16)
-    mat2 = mat2.to(torch.bfloat16)
+    bias = linear.bias.detach()
+    weight = linear.weight.detach()
     mat1_flat = mat1.view(-1, mat1.shape[-1])
 
     if not torch.cuda.is_available():
-        # aten::_addmm_activation is a CUDA-only fused kernel; fall back to
-        # standard ops on CPU / MPS. Use float32 — bfloat16 matmul accumulation
-        # is unsupported on MPS.
-        x = mat1_flat.float()
-        w = mat2.float()
-        b = self.float()
+        # aten::_addmm_activation is a CUDA-only fused kernel.
+        # Cast everything to the weight dtype (float32 after model.float()) so
+        # the computation stays consistent regardless of the input's dtype.
+        target_dtype = weight.dtype
+        x = mat1_flat.to(target_dtype)
+        w = weight.to(target_dtype)
+        b = bias.to(target_dtype)
         y = torch.nn.functional.linear(x, w, b)
         if activation in [torch.nn.functional.relu, torch.nn.ReLU]:
             y = torch.relu(y)
@@ -31,8 +29,12 @@ def addmm_act(activation, linear, mat1):
             y = torch.nn.functional.gelu(y)
         else:
             raise ValueError(f"Unexpected activation {activation}")
-        return y.to(mat1.dtype).view(mat1.shape[:-1] + (y.shape[-1],))
+        return y.view(mat1.shape[:-1] + (y.shape[-1],))
 
+    # CUDA path: use bfloat16 fused kernel
+    self = bias.to(torch.bfloat16)
+    mat1_flat = mat1_flat.to(torch.bfloat16)
+    mat2 = weight.to(torch.bfloat16)
     if activation in [torch.nn.functional.relu, torch.nn.ReLU]:
         y = addmm_act_op(self, mat1_flat, mat2.t(), beta=1, alpha=1, use_gelu=False)
         return y.view(mat1.shape[:-1] + (y.shape[-1],))

--- a/sam3/perflib/fused.py
+++ b/sam3/perflib/fused.py
@@ -19,15 +19,19 @@ def addmm_act(activation, linear, mat1):
 
     if not torch.cuda.is_available():
         # aten::_addmm_activation is a CUDA-only fused kernel; fall back to
-        # standard ops on CPU / MPS.
-        y = mat1_flat @ mat2.t() + self
+        # standard ops on CPU / MPS. Use float32 — bfloat16 matmul accumulation
+        # is unsupported on MPS.
+        x = mat1_flat.float()
+        w = mat2.float()
+        b = self.float()
+        y = torch.nn.functional.linear(x, w, b)
         if activation in [torch.nn.functional.relu, torch.nn.ReLU]:
             y = torch.relu(y)
         elif activation in [torch.nn.functional.gelu, torch.nn.GELU]:
             y = torch.nn.functional.gelu(y)
         else:
             raise ValueError(f"Unexpected activation {activation}")
-        return y.view(mat1.shape[:-1] + (y.shape[-1],))
+        return y.to(mat1.dtype).view(mat1.shape[:-1] + (y.shape[-1],))
 
     if activation in [torch.nn.functional.relu, torch.nn.ReLU]:
         y = addmm_act_op(self, mat1_flat, mat2.t(), beta=1, alpha=1, use_gelu=False)

--- a/sam3/train/utils/distributed.py
+++ b/sam3/train/utils/distributed.py
@@ -143,7 +143,7 @@ def all_gather(data, force_cpu=False, force_filesys=False, filesys_save_dir=None
     buffer = io.BytesIO()
     torch.save(data, buffer)
     data_view = buffer.getbuffer()
-    device = "cuda" if cpu_group is None else "cpu"
+    device = "cuda" if (cpu_group is None and torch.cuda.is_available()) else "cpu"
     tensor = torch.ByteTensor(data_view).to(device)
 
     # obtain Tensor size of each rank


### PR DESCRIPTION
triton is Linux/CUDA-only and fails to import on macOS. Wrap the import in try/except, guard the @triton.jit kernel behind _TRITON_AVAILABLE, and add a cv2.distanceTransform fallback in edt_triton for non-CUDA environments.