### PR TITLE
docs: clarify predictor request flow and box formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,8 +157,23 @@ response = video_predictor.handle_request(
         text="<YOUR_TEXT_PROMPT>",
     )
 )
-output = response["outputs"]
+prompted_frame_output = response["outputs"]
+
+for result in video_predictor.handle_stream_request(
+    request=dict(
+        type="propagate_in_video",
+        session_id=response["session_id"],
+    )
+):
+    frame_idx = result["frame_index"]
+    frame_output = result["outputs"]
 ```
+
+### API Notes
+
+- `Sam3Processor` is the convenience API for image inference. `processor.set_text_prompt(...)` returns `boxes` in absolute pixel coordinates using `[x0, y0, x1, y1]` (`xyxy`) format.
+- `build_sam3_video_predictor()` exposes a request-based API. Use `handle_request(...)` for one-shot operations such as `start_session` and `add_prompt`, and use `handle_stream_request(...)` for `propagate_in_video`, which yields one result per frame.
+- For video prompts, `add_prompt` expects `bounding_boxes` in normalized `[x_min, y_min, width, height]` (`xywh`) format. Video outputs expose `out_boxes_xywh` in the same normalized `xywh` convention.
 
 ## Examples
 


### PR DESCRIPTION
## Summary
- clarify the README example flow for one-shot video requests vs streamed propagation
- document the box coordinate conventions exposed by the image and video inference APIs
- keep the change limited to the current public contract described by the implementation

## Why
Issue #514 calls out ambiguity around the predictor API flow and box coordinate formats. This PR tightens the top-level README so users do not need to inspect the implementation to understand which API streams and which box format each surface returns.

## Scope
This is a docs-only clarification PR. It does not change runtime behavior.

## Validation
- reviewed the README wording against `sam3/model/sam3_base_predictor.py`
- reviewed the box-format wording against `sam3/model/sam3_image_processor.py` and `sam3/model/sam3_video_inference.py`
- ran `git diff --check`
