### PR TITLE
Fix video preprocessing bug in OpenCV loader

### DIFF
--- a/sam3/model/io_utils.py
+++ b/sam3/model/io_utils.py
@@ -332,6 +332,8 @@ def load_video_frames_from_video_file_using_cv2(
     # Convert to tensor
     frames_np = np.stack(frames, axis=0).astype(np.float32)  # (T, H, W, C)
     video_tensor = torch.from_numpy(frames_np).permute(0, 3, 1, 2)  # (T, C, H, W)
+    video_tensor = video_tensor.to(dtype=torch.float16)
+    video_tensor /= 255.0
 
     img_mean = torch.tensor(img_mean, dtype=torch.float16).view(1, 3, 1, 1)
     img_std = torch.tensor(img_std, dtype=torch.float16).view(1, 3, 1, 1)


### PR DESCRIPTION
## Summary
This PR fixes a bug in the OpenCV video loader used for video-file inputs. Specifically, the function `load_video_frames_from_video_file_using_cv2` in https://github.com/facebookresearch/sam3/blob/44ef224799e7b32e017855823883909d38ffb30f/sam3/model/io_utils.py#L332-L345
where decoded video frames were normalized without first being scaled from `[0, 255]` to `[0, 1]`, even though the normalization parameters assume `[0, 1]` inputs. This leads to incorrectly scaled model inputs during video inference.
While in image folder loadings, `/ 255.0` is correctly placed:
https://github.com/facebookresearch/sam3/blob/44ef224799e7b32e017855823883909d38ffb30f/sam3/model/io_utils.py#L56 
And in torchcodec, too:
https://github.com/facebookresearch/sam3/blob/44ef224799e7b32e017855823883909d38ffb30f/sam3/model/io_utils.py#L689
## Changes
- divide decoded OpenCV video frames by `255.0` before mean/std normalization
- convert video tensor to torch.float16 to align with other loading approaches
## Validation
- Without fixing, the `images` tensor after `init_state` as below is in [-1, 509] when loading mp4 video through opencv which is incorrect, and I have also seen the unusual results
https://github.com/facebookresearch/sam3/blob/44ef224799e7b32e017855823883909d38ffb30f/sam3/model/sam3_video_inference.py#L63-L71
- After fixing, the `images` tensor is always in [-1, 1], and the segmentation results are good
