### PR TITLE
Fix exclusive FLASH_ATTENTION sdpa_kernel in decoder.py

### DIFF
--- a/sam3/model/decoder.py
+++ b/sam3/model/decoder.py
@@ -1011,7 +1011,7 @@ def functional_attention(
         assert dropout == 0.0
         out = flash_attn_func(q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2))
     else:
-        with sdpa_kernel(SDPBackend.FLASH_ATTENTION):
+        with sdpa_kernel([SDPBackend.FLASH_ATTENTION, SDPBackend.EFFICIENT_ATTENTION, SDPBackend.MATH]):
             out = torchF.scaled_dot_product_attention(q, k, v, dropout_p=dropout)
         out = out.transpose(1, 2)  #  B * n * n_heads * (cv // num_heads)
 


### PR DESCRIPTION
Closes https://github.com/facebookresearch/sam3/issues/523

`sdpa_kernel` is exclusive, passing a single backend disables all others. This crashes on platforms where Flash Attention isn't compiled (e.g. Windows PyTorch builds) with `No available kernel. Aborting execution.`

Allows all three backends, matching [what vl_combiner.py already does](https://github.com/facebookresearch/sam3/blob/main/sam3/model/vl_combiner.py#L150).