### PR TITLE
Fix: Migrate pkg_resources to import lib.resources for Python 3.9+ compatibility

### DIFF
--- a/sam3/model_builder.py
+++ b/sam3/model_builder.py
@@ -5,7 +5,7 @@
 import os
 from typing import Optional
 
-import pkg_resources
+from importlib.resources import files as _importlib_files
 import torch
 import torch.nn as nn
 from huggingface_hub import hf_hub_download
@@ -596,9 +596,7 @@ def build_sam3_image_model(
         A SAM3 image model
     """
     if bpe_path is None:
-        bpe_path = pkg_resources.resource_filename(
-            "sam3", "assets/bpe_simple_vocab_16e6.txt.gz"
-        )
+        bpe_path = str(_importlib_files("sam3").joinpath("assets/bpe_simple_vocab_16e6.txt.gz"))
 
     # Create visual components
     compile_mode = "default" if compile else None
@@ -695,9 +693,7 @@ def build_sam3_video_model(
         Sam3VideoInferenceWithInstanceInteractivity: The instantiated dense tracking model
     """
     if bpe_path is None:
-        bpe_path = pkg_resources.resource_filename(
-            "sam3", "assets/bpe_simple_vocab_16e6.txt.gz"
-        )
+        bpe_path = str(_importlib_files("sam3").joinpath("assets/bpe_simple_vocab_16e6.txt.gz"))
 
     # Build Tracker module
     tracker = build_tracker(apply_temporal_disambiguation=apply_temporal_disambiguation)
@@ -1105,9 +1101,7 @@ def build_sam3_multiplex_video_predictor(
         Sam3MultiplexVideoPredictor: The fully-initialized predictor
     """
     if bpe_path is None:
-        bpe_path = pkg_resources.resource_filename(
-            "sam3", "assets/bpe_simple_vocab_16e6.txt.gz"
-        )
+        bpe_path = str(_importlib_files("sam3").joinpath("assets/bpe_simple_vocab_16e6.txt.gz"))
 
     from sam3.model.sam3_multiplex_base import Sam3MultiplexPredictorWrapper
     from sam3.model.sam3_multiplex_detector import Sam3MultiplexDetector


### PR DESCRIPTION
#### **Summary**
This PR replaces the deprecated `pkg_resources.resource_filename()` with `importlib.resources.files()` in `sam3/model_builder.py`. This migration is necessary to support `setuptools >= 82.0.0`, which removed the `pkg_resources` API.

#### **Changes**
* Removed `import pkg_resources`.
* Integrated `from importlib.resources import files`.
* Updated the following functions to use `importlib` for asset path resolution:
    * `build_sam3_image_model`
    * `build_sam3_video_model`
    * `build_sam3_multiplex_video_predictor`
* Cast `Traversable` objects to `str` to ensure backward compatibility with `SimpleTokenizer`.

#### **Context**
The previous implementation relied on an API that is no longer available in the latest `setuptools` releases, causing installation and runtime failures in modern Python environments. Using `importlib.resources` (available since Python 3.9) provides a stable, built-in solution and removes the runtime dependency on `setuptools` for asset resolution.

#### **Related Issues**
Fixes #462