### PR TITLE
Fix: apply inspect-based kwarg filtering to start_session() to fix multiplex predictor TypeError

### DIFF
--- a/sam3/model/sam3_base_predictor.py
+++ b/sam3/model/sam3_base_predictor.py
@@ -133,6 +133,14 @@ class Sam3BasePredictor:
             init_kwargs["async_loading_frames"] = self.async_loading_frames
         if hasattr(self, "video_loader_type"):
             init_kwargs["video_loader_type"] = self.video_loader_type
+        
+        # Filter init_kwargs to only pass what the model's init_state() accepts
+        import inspect
+
+        sig = inspect.signature(self.model.init_state)
+        valid_params = set(sig.parameters.keys())
+        init_kwargs = {k: v for k, v in init_kwargs.items() if k in valid_params}
+        
         inference_state = self.model.init_state(**init_kwargs)
 
         if not session_id:


### PR DESCRIPTION
## Problem

When using SAM 3.1 with `build_sam3_multiplex_video_predictor`, calling `handle_request(request=dict(type="start_session", ...))` raises:
```bash
TypeError: Sam3MultiplexTrackingWithInteractivity.init_state() 
got an unexpected keyword argument 'offload_state_to_cpu'
```
This happens because `start_session()` unconditionally passes 
`offload_state_to_cpu` to `self.model.init_state()`, but
[`Sam3MultiplexTrackingWithInteractivity.init_state()`](https://github.com/facebookresearch/sam3/blob/main/sam3/model/sam3_multiplex_tracking.py) does not accept
this parameter.

## Root Cause

[`sam3_base_predictor.py`](https://github.com/facebookresearch/sam3/blob/main/sam3/model/sam3_base_predictor.py) already uses `inspect.signature` to filter
kwargs in `add_prompt()` and `propagate_in_video()`, but `start_session()`
was missing the same guard.

## Fix

Apply the same `inspect`-based filtering pattern already used in this
file to `start_session()`, so only parameters accepted by the underlying
model's `init_state()` are forwarded.

## Reproduction

Run the official [`sam3.1_video_predictor_example.ipynb`](https://github.com/facebookresearch/sam3/blob/main/examples/sam3.1_video_predictor_example.ipynb) with a
multiplex predictor — the `start_session` call on cell [11] raises
the TypeError above.

## Testing

Ran the existing test suite to confirm no regressions:

```
$ python -m pytest test/test_io_utils.py -v
============================================================== test session starts ==============================================================
platform linux -- Python 3.12.3, pytest-8.1.1, pluggy-1.6.0
rootdir: /home/kuihao/Git/sam3
configfile: pyproject.toml
plugins: cov-7.1.0, hydra-core-1.3.2, anyio-4.9.0, flakefinder-1.1.0, xdoctest-1.0.2, shard-0.1.2, xdist-3.6.1, hypothesis-6.130.8, rerunfailures-15.1, typeguard-4.3.0
collected 8 items                                                                                                                               
Running 8 items in this shard

test/test_io_utils.py ........                                                                                                            [100%]

=============================================================== warnings summary ================================================================
sam3/model_builder.py:8
  /home/kuihao/Git/sam3/sam3/model_builder.py:8: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    import pkg_resources

../../../../usr/local/lib/python3.12/dist-packages/timm/models/layers/__init__.py:49
  /usr/local/lib/python3.12/dist-packages/timm/models/layers/__init__.py:49: FutureWarning: Importing from timm.models.layers is deprecated, please import via timm.layers
    warnings.warn(f"Importing from {__name__} is deprecated, please import via timm.layers", FutureWarning)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================= 8 passed, 2 warnings in 1.64s =========================================================

```

No existing unit test covers `start_session()` kwarg filtering.
The fix was verified end-to-end via [`sam3.1_video_predictor_example.ipynb`](https://github.com/facebookresearch/sam3/blob/main/examples/sam3.1_video_predictor_example.ipynb)
with a multiplex predictor — cell [11] no longer raises `TypeError`.

Happy to add a dedicated unit test if maintainers can point to
the preferred location for predictor-layer test coverage.

Fixes [#544](https://github.com/facebookresearch/sam3/issues/544)