### PR TITLE
Update SAM3 to be compatible with newer numpy and other devices

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,13 +26,15 @@ classifiers = [
 ]
 dependencies = [
     "timm>=1.0.17",
-    "numpy>=1.26,<2",
+    "numpy>=1.26",
     "tqdm",
     "ftfy==6.1.1",
     "regex",
     "iopath>=0.1.10",
     "typing_extensions",
     "huggingface_hub",
+    "einops",
+    "pycocotools",
 ]
 
 [project.optional-dependencies]

--- a/sam3/agent/helpers/visualizer.py
+++ b/sam3/agent/helpers/visualizer.py
@@ -224,7 +224,7 @@ class _PanopticPrediction:
         assert len(empty_ids) == 1, (
             ">1 ids corresponds to no labels. This is currently not supported"
         )
-        return (self._seg != empty_ids[0]).numpy().astype(np.bool)
+        return (self._seg != empty_ids[0]).numpy().astype(np.bool_)
 
     def semantic_masks(self):
         for sid in self._seg_ids:
@@ -232,14 +232,14 @@ class _PanopticPrediction:
             if sinfo is None or sinfo["isthing"]:
                 # Some pixels (e.g. id 0 in PanopticFPN) have no instance or semantic predictions.
                 continue
-            yield (self._seg == sid).numpy().astype(np.bool), sinfo
+            yield (self._seg == sid).numpy().astype(np.bool_), sinfo
 
     def instance_masks(self):
         for sid in self._seg_ids:
             sinfo = self._sinfo.get(sid)
             if sinfo is None or not sinfo["isthing"]:
                 continue
-            mask = (self._seg == sid).numpy().astype(np.bool)
+            mask = (self._seg == sid).numpy().astype(np.bool_)
             if mask.sum() > 0:
                 yield mask, sinfo
 

--- a/sam3/model/decoder.py
+++ b/sam3/model/decoder.py
@@ -5,7 +5,7 @@
 Transformer decoder.
 Inspired from Pytorch's version, adds the pre-norm variant
 """
-
+from contextlib import nullcontext
 import math
 from functools import partial
 from typing import Any, Dict, List, Optional, Union
@@ -73,8 +73,15 @@ class TransformerDecoderLayer(nn.Module):
         return tensor if pos is None else tensor + pos
 
     def forward_ffn(self, tgt):
-        with torch.amp.autocast(device_type="cuda", enabled=False):
+        device_type = tgt.device.type
+        if device_type in {"cuda", "cpu"}:
+            autocast_ctx = torch.amp.autocast(device_type=device_type, enabled=False)
+        else:
+            autocast_ctx = nullcontext()
+
+        with autocast_ctx:
             tgt2 = self.linear2(self.dropout3(self.activation(self.linear1(tgt))))
+
         tgt = tgt + self.dropout4(tgt2)
         tgt = self.norm3(tgt)
         return tgt
@@ -280,7 +287,7 @@ class TransformerDecoder(nn.Module):
             if resolution is not None and stride is not None:
                 feat_size = resolution // stride
                 coords_h, coords_w = self._get_coords(
-                    feat_size, feat_size, device="cuda"
+                    feat_size, feat_size, device='cpu'
                 )
                 self.compilable_cord_cache = (coords_h, coords_w)
                 self.compilable_stored_size = (feat_size, feat_size)
@@ -355,6 +362,10 @@ class TransformerDecoder(nn.Module):
 
             assert coords_h.shape == (H,)
             assert coords_w.shape == (W,)
+
+        if coords_h.device != reference_boxes.device:
+            coords_h = coords_h.to(reference_boxes.device)
+            coords_w = coords_w.to(reference_boxes.device)
 
         deltas_y = coords_h.view(1, -1, 1) - boxes_xyxy.reshape(-1, 1, 4)[:, :, 1:4:2]
         deltas_y = deltas_y.view(bs, num_queries, -1, 2)

--- a/sam3/model/geometry_encoders.py
+++ b/sam3/model/geometry_encoders.py
@@ -602,9 +602,16 @@ class SequenceGeometryEncoder(nn.Module):
             grid = points.transpose(0, 1).unsqueeze(2)
             # re normalize to [-1, 1]
             grid = (grid * 2) - 1
-            sampled = torch.nn.functional.grid_sample(
-                img_feats, grid, align_corners=False
-            )
+            if img_feats.device.type == 'mps':
+                img_feats_cpu = img_feats.cpu()
+                grid_cpu = grid.cpu()
+                sampled = torch.nn.functional.grid_sample(
+                    img_feats_cpu, grid_cpu, align_corners=False
+                ).to(img_feats.device)
+            else:
+                sampled = torch.nn.functional.grid_sample(
+                    img_feats, grid, align_corners=False
+                )
             assert list(sampled.shape) == [bs, self.d_model, n_points, 1]
             sampled = sampled.squeeze(-1).permute(2, 0, 1)
             proj = self.points_pool_project(sampled)
@@ -645,7 +652,10 @@ class SequenceGeometryEncoder(nn.Module):
             # We need to denormalize, and convert to [x, y, x, y]
             boxes_xyxy = box_cxcywh_to_xyxy(boxes)
             scale = torch.tensor([W, H, W, H], dtype=boxes_xyxy.dtype)
-            scale = scale.pin_memory().to(device=boxes_xyxy.device, non_blocking=True)
+            if boxes_xyxy.device.type == 'cuda':
+                scale = scale.pin_memory().to(device=boxes_xyxy.device, non_blocking=True)
+            else:
+                scale = scale.to(device=boxes_xyxy.device)
             scale = scale.view(1, 1, 4)
             boxes_xyxy = boxes_xyxy * scale
             sampled = torchvision.ops.roi_align(

--- a/sam3/model/position_encoding.py
+++ b/sam3/model/position_encoding.py
@@ -52,7 +52,7 @@ class PositionEmbeddingSine(nn.Module):
                 (precompute_resolution // 32, precompute_resolution // 32),
             ]
             for size in precompute_sizes:
-                tensors = torch.zeros((1, 1) + size, device="cuda")
+                tensors = torch.zeros((1, 1) + size)
                 self.forward(tensors)
                 # further clone and detach it in the cache (just to be safe)
                 self.cache[size] = self.cache[size].clone().detach()
@@ -98,7 +98,8 @@ class PositionEmbeddingSine(nn.Module):
         cache_key = None
         cache_key = (x.shape[-2], x.shape[-1])
         if cache_key in self.cache:
-            return self.cache[cache_key][None].repeat(x.shape[0], 1, 1, 1)
+            cached = self.cache[cache_key].to(x.device)
+            return cached[None].repeat(x.shape[0], 1, 1, 1)
         y_embed = (
             torch.arange(1, x.shape[-2] + 1, dtype=torch.float32, device=x.device)
             .view(1, -1, 1)

--- a/sam3/model/sam3_base_predictor.py
+++ b/sam3/model/sam3_base_predictor.py
@@ -202,8 +202,13 @@ class Sam3BasePredictor:
         valid_params = set(sig.parameters.keys())
         filtered_kwargs = {k: v for k, v in kwargs.items() if k in valid_params}
 
-        with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+        device_type = next(self.model.parameters()).device.type
+        if device_type == "mps":
+            # MPS doesn't support bfloat16 autocast; run in float32
             frame_idx, outputs = self.model.add_prompt(**filtered_kwargs)
+        else:
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                frame_idx, outputs = self.model.add_prompt(**filtered_kwargs)
         return {"frame_index": frame_idx, "outputs": outputs}
 
     def remove_object(

--- a/sam3/model/sam3_image_processor.py
+++ b/sam3/model/sam3_image_processor.py
@@ -14,9 +14,12 @@ from torchvision.transforms import v2
 class Sam3Processor:
     """ """
 
-    def __init__(self, model, resolution=1008, device="cuda", confidence_threshold=0.5):
+    def __init__(self, model, resolution=1008, device=None, confidence_threshold=0.5):
         self.model = model
         self.resolution = resolution
+
+        if device is None:
+            device = next(model.parameters()).device
         self.device = device
         self.transform = v2.Compose(
             [

--- a/sam3/model/sam3_tracker_utils.py
+++ b/sam3/model/sam3_tracker_utils.py
@@ -6,7 +6,6 @@ import numpy as np
 import torch
 import torch.nn.functional as F
 from numpy.typing import NDArray
-from sam3.model.edt import edt_triton
 
 
 def sample_box_points(
@@ -175,6 +174,8 @@ def sample_one_point_from_error_center(gt_masks, pred_masks, padding=True):
     else:
         padded_fp_masks = fp_masks
         padded_fn_masks = fn_masks
+
+    from sam3.model.edt import edt_triton
 
     fn_mask_dt = edt_triton(padded_fn_masks)
     fp_mask_dt = edt_triton(padded_fp_masks)

--- a/sam3/model/sam3_tracking_predictor.py
+++ b/sam3/model/sam3_tracking_predictor.py
@@ -47,7 +47,11 @@ class Sam3TrackerPredictor(Sam3TrackerBase):
         self.max_point_num_in_prompt_enc = max_point_num_in_prompt_enc
         self.non_overlap_masks_for_output = non_overlap_masks_for_output
 
-        self.bf16_context = torch.autocast(device_type="cuda", dtype=torch.bfloat16)
+        device_type = next(self.parameters()).device.type
+        if device_type == "mps":
+            self.bf16_context = torch.autocast(device_type="mps", dtype=torch.float16)
+        else:
+            self.bf16_context = torch.autocast(device_type, dtype=torch.bfloat16)
         self.bf16_context.__enter__()  # keep using for the entire model process
 
         self.iter_use_prev_mask_pred = True

--- a/sam3/model_builder.py
+++ b/sam3/model_builder.py
@@ -63,6 +63,16 @@ def _setup_tf32() -> None:
 _setup_tf32()
 
 
+def get_default_device():
+    """Get the default device with priority: CUDA > MPS > CPU."""
+    if torch.cuda.is_available():
+        return "cuda"
+    elif torch.backends.mps.is_available():
+        return "mps"
+    else:
+        return "cpu"
+
+
 def _create_position_encoding(precompute_resolution=None):
     """Create position encoding for visual backbone."""
     return PositionEmbeddingSine(
@@ -563,8 +573,9 @@ def _load_checkpoint(model, checkpoint_path):
 
 def _setup_device_and_mode(model, device, eval_mode):
     """Setup model device and evaluation mode."""
-    if device == "cuda":
-        model = model.cuda()
+    if str(device) == "mps":
+        model = model.float()
+    model = model.to(device)
     if eval_mode:
         model.eval()
     return model
@@ -572,7 +583,7 @@ def _setup_device_and_mode(model, device, eval_mode):
 
 def build_sam3_image_model(
     bpe_path=None,
-    device="cuda" if torch.cuda.is_available() else "cpu",
+    device=None,
     eval_mode=True,
     checkpoint_path=None,
     load_from_HF=True,
@@ -585,7 +596,7 @@ def build_sam3_image_model(
 
     Args:
         bpe_path: Path to the BPE tokenizer vocabulary
-        device: Device to load the model on ('cuda' or 'cpu')
+        device: Device to load the model on ('cuda', 'mps', or 'cpu'). If None, autodetect.
         eval_mode: Whether to set the model to evaluation mode
         checkpoint_path: Optional path to model checkpoint
         enable_segmentation: Whether to enable segmentation head
@@ -595,6 +606,9 @@ def build_sam3_image_model(
     Returns:
         A SAM3 image model
     """
+    if device is None:
+        device = get_default_device()
+
     if bpe_path is None:
         bpe_path = pkg_resources.resource_filename(
             "sam3", "assets/bpe_simple_vocab_16e6.txt.gz"
@@ -681,7 +695,7 @@ def build_sam3_video_model(
     geo_encoder_use_img_cross_attn: bool = True,
     strict_state_dict_loading: bool = True,
     apply_temporal_disambiguation: bool = True,
-    device="cuda" if torch.cuda.is_available() else "cpu",
+    device=None,
     compile=False,
 ) -> Sam3VideoInferenceWithInstanceInteractivity:
     """
@@ -690,10 +704,14 @@ def build_sam3_video_model(
     Args:
         checkpoint_path: Optional path to checkpoint file
         bpe_path: Path to the BPE tokenizer file
+        device: Device to load the model on ('cuda', 'mps', or 'cpu'). If None, autodetect.
 
     Returns:
         Sam3VideoInferenceWithInstanceInteractivity: The instantiated dense tracking model
     """
+    if device is None:
+        device = get_default_device()
+
     if bpe_path is None:
         bpe_path = pkg_resources.resource_filename(
             "sam3", "assets/bpe_simple_vocab_16e6.txt.gz"
@@ -941,7 +959,7 @@ def build_sam3_multiplex_video_model(
     use_fa3: bool = False,
     use_rope_real: bool = False,
     strict_state_dict_loading: bool = True,
-    device="cuda" if torch.cuda.is_available() else "cpu",
+    device=None,
     compile=False,
 ):
     """
@@ -953,12 +971,15 @@ def build_sam3_multiplex_video_model(
         use_fa3: Whether to use FlashAttention 3
         use_rope_real: Whether to use real-valued RoPE (for compile compat)
         strict_state_dict_loading: Whether to use strict state dict loading
-        device: Device to place model on
+        device: Device to place model on ('cuda', 'mps', or 'cpu'). If None, autodetect.
         compile: Whether to compile model components
 
     Returns:
         VideoTrackingDynamicMultiplex: The instantiated multiplex tracking model
     """
+    if device is None:
+        device = get_default_device()
+
     # Build multiplex-specific components
     maskmem_backbone = _create_multiplex_maskmem_backbone(
         multiplex_count=multiplex_count

--- a/sam3/model_builder.py
+++ b/sam3/model_builder.py
@@ -610,8 +610,8 @@ def build_sam3_image_model(
         device = get_default_device()
 
     if bpe_path is None:
-        bpe_path = pkg_resources.resource_filename(
-            "sam3", "assets/bpe_simple_vocab_16e6.txt.gz"
+        bpe_path = os.path.join(
+            os.path.dirname(__file__), "assets", "bpe_simple_vocab_16e6.txt.gz"
         )
 
     # Create visual components
@@ -713,8 +713,8 @@ def build_sam3_video_model(
         device = get_default_device()
 
     if bpe_path is None:
-        bpe_path = pkg_resources.resource_filename(
-            "sam3", "assets/bpe_simple_vocab_16e6.txt.gz"
+        bpe_path = os.path.join(
+            os.path.dirname(__file__), "assets", "bpe_simple_vocab_16e6.txt.gz"
         )
 
     # Build Tracker module
@@ -1126,8 +1126,8 @@ def build_sam3_multiplex_video_predictor(
         Sam3MultiplexVideoPredictor: The fully-initialized predictor
     """
     if bpe_path is None:
-        bpe_path = pkg_resources.resource_filename(
-            "sam3", "assets/bpe_simple_vocab_16e6.txt.gz"
+        bpe_path = os.path.join(
+            os.path.dirname(__file__), "assets", "bpe_simple_vocab_16e6.txt.gz"
         )
 
     from sam3.model.sam3_multiplex_base import Sam3MultiplexPredictorWrapper

--- a/sam3/perflib/fused.py
+++ b/sam3/perflib/fused.py
@@ -10,6 +10,16 @@ addmm_act_op = torch.ops.aten._addmm_activation
 def addmm_act(activation, linear, mat1):
     if torch.is_grad_enabled():
         raise ValueError("Expected grad to be disabled.")
+
+    # Fused bfloat16 path only works on CUDA
+    if mat1.device.type != "cuda":
+        x = torch.nn.functional.linear(mat1, linear.weight, linear.bias)
+        if activation in [torch.nn.functional.relu, torch.nn.ReLU]:
+            return torch.nn.functional.relu(x)
+        if activation in [torch.nn.functional.gelu, torch.nn.GELU]:
+            return torch.nn.functional.gelu(x)
+        raise ValueError(f"Unexpected activation {activation}")
+
     self = linear.bias.detach()
     mat2 = linear.weight.detach()
     self = self.to(torch.bfloat16)


### PR DESCRIPTION
# Summary
SAM3's pinned numpy requirements as of https://github.com/facebookresearch/sam3/tree/4cbac146c1b5a1e3a7f5c6a894901090b4dfd65b showed numpy>=1.26.4 <2, which created conflicts with supervision and inference. Also, SAM3 does not have native support for other device types. 

This PR does the following: 
- Add MPS (Apple Silicon) and CPU device support — the official SAM3 assumes CUDA throughout                                         
- Fix numpy 2.0 compatibility                                                                              
- Fix asset path resolution to work with all install methods (git, editable, etc.)  

 ## Changes
 Device compatibility (MPS/CPU):
  - Auto-detect device (CUDA → MPS → CPU) instead of hardcoding "cuda" in all builder functions
  - Replace model.cuda() with model.to(device) and force float32 on MPS (no bfloat16 support)
  - Wrap torch.amp.autocast with device checks — MPS doesn't support autocast, so use nullcontext as fallback
  - Add standard F.linear + activation fallback in perflib/fused.py — torch.ops.aten._addmm_activation is CUDA-only
  - Move grid_sample to CPU on MPS (MPS has incomplete grid_sample support)
  - Guard pin_memory() behind CUDA check (pin_memory is CUDA-only)
  - Move position encoding precomputation off hardcoded "cuda" device
  - Fix coordinate cache device mismatch in decoder
  - Lazy-import edt_triton (Triton is CUDA-only, import fails on MPS)

  numpy 2.0:
  - Replace deprecated np.bool with np.bool_ in visualizer

  Asset paths:
  - Replace pkg_resources.resource_filename() with os.path.dirname(__file__) — more reliable across install methods