### PR TITLE
Fix: Allow SDPA backend fallback in decoder.py (Fixes #523) + README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ various types of prompts:
   further interactive refinements with points.
 - [`sam3_image_batched_inference.ipynb`](examples/sam3_image_batched_inference.ipynb)
   : Demonstrates how to run batched inference with SAM 3 on images.
-- [`sam3_agent.ipynb`](examples/sam3_agent.ipynb): Demonsterates the use of SAM
+- [`sam3_agent.ipynb`](examples/sam3_agent.ipynb): Demonstrates the use of SAM
   3 Agent to segment complex text prompt on images.
 - [`saco_gold_silver_vis_example.ipynb`](examples/saco_gold_silver_vis_example.ipynb)
   : Shows a few examples from SA-Co image evaluation set.

--- a/sam3/model/decoder.py
+++ b/sam3/model/decoder.py
@@ -1011,7 +1011,13 @@ def functional_attention(
         assert dropout == 0.0
         out = flash_attn_func(q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2))
     else:
-        with sdpa_kernel(SDPBackend.FLASH_ATTENTION):
+        with sdpa_kernel(
+            [
+                SDPBackend.FLASH_ATTENTION,
+                SDPBackend.EFFICIENT_ATTENTION,
+                SDPBackend.MATH,
+            ]
+        ):
             out = torchF.scaled_dot_product_attention(q, k, v, dropout_p=dropout)
         out = out.transpose(1, 2)  #  B * n * n_heads * (cv // num_heads)
 


### PR DESCRIPTION
Fixes #523. Fix SDPA fallback and README typo.