### PR TITLE
Security: Unsafe tarfile extraction without validation in download script

### DIFF
--- a/scripts/eval/silver/download_inaturalist.py
+++ b/scripts/eval/silver/download_inaturalist.py
@@ -27,10 +27,17 @@ def download_archive(url, dest_dir):
     return archive_path
 
 
+def _is_safe_tar_member(member, dest_dir):
+    dest_path = Path(dest_dir).resolve()
+    member_path = (dest_path / member.name).resolve()
+    return member_path.is_relative_to(dest_path) and ".." not in member.name
+
+
 def extract_archive(archive_path, dest_dir):
     print(f"Extracting {archive_path} to {dest_dir}...")
     with tarfile.open(archive_path, "r:gz") as tar:
-        tar.extractall(path=dest_dir)
+        safe_members = [m for m in tar.getmembers() if _is_safe_tar_member(m, dest_dir)]
+        tar.extractall(path=dest_dir, members=safe_members)
     print("Extraction complete.")
 
 


### PR DESCRIPTION
## Problem

The `extract_archive` function in `scripts/eval/silver/download_inaturalist.py` uses `tarfile.extractall()` without any validation of the extracted paths. This can lead to a directory traversal vulnerability (Zip Slip/Tar Slip) where a malicious archive could overwrite arbitrary files on the system if it contains entries with relative paths like `../../etc/passwd`.

**Severity**: `high`
**File**: `scripts/eval/silver/download_inaturalist.py`

## Solution

Use `tarfile.extractall()` with a `members` parameter that filters out paths containing `..` or absolute paths, or use `pathlib.Path` to validate that extracted files stay within the destination directory. Consider using `shutil.unpack_archive` with proper validation or implementing a safe extraction wrapper.

## Changes

- `scripts/eval/silver/download_inaturalist.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
