### PR TITLE
solve No module named 'torch' and  Module pkg_resources not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ pip install -e ".[train,dev]"
 5. **Optional dependencies for faster inference**
 ```bash
 pip install einops ninja && pip install flash-attn-3 --no-deps --index-url https://download.pytorch.org/whl/cu128
-pip install git+https://github.com/ronghanghu/cc_torch.git
+python -m pip install --no-build-isolation git+https://github.com/ronghanghu/cc_torch.git
 ```
 
 ## Getting Started

--- a/sam3/model_builder.py
+++ b/sam3/model_builder.py
@@ -5,7 +5,7 @@
 import os
 from typing import Optional
 
-import pkg_resources
+from importlib.resources import files as _importlib_files
 import torch
 import torch.nn as nn
 from huggingface_hub import hf_hub_download
@@ -596,8 +596,8 @@ def build_sam3_image_model(
         A SAM3 image model
     """
     if bpe_path is None:
-        bpe_path = pkg_resources.resource_filename(
-            "sam3", "assets/bpe_simple_vocab_16e6.txt.gz"
+        bpe_path = str(
+            _importlib_files("sam3").joinpath("assets", "bpe_simple_vocab_16e6.txt.gz")
         )
 
     # Create visual components
@@ -695,8 +695,8 @@ def build_sam3_video_model(
         Sam3VideoInferenceWithInstanceInteractivity: The instantiated dense tracking model
     """
     if bpe_path is None:
-        bpe_path = pkg_resources.resource_filename(
-            "sam3", "assets/bpe_simple_vocab_16e6.txt.gz"
+        bpe_path = str(
+            _importlib_files("sam3").joinpath("assets", "bpe_simple_vocab_16e6.txt.gz")
         )
 
     # Build Tracker module
@@ -1105,8 +1105,8 @@ def build_sam3_multiplex_video_predictor(
         Sam3MultiplexVideoPredictor: The fully-initialized predictor
     """
     if bpe_path is None:
-        bpe_path = pkg_resources.resource_filename(
-            "sam3", "assets/bpe_simple_vocab_16e6.txt.gz"
+        bpe_path = str(
+            _importlib_files("sam3").joinpath("assets", "bpe_simple_vocab_16e6.txt.gz")
         )
 
     from sam3.model.sam3_multiplex_base import Sam3MultiplexPredictorWrapper


### PR DESCRIPTION
Some packages are built in an isolated environment. During installation, the build environment may not have access to already-installed torch version, causing the error even though torch exists in the Conda environment.