### PR TITLE
ci: declare read-only token permissions on formatter check

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -3,6 +3,10 @@ on:
   pull_request:
     branches:
     - main
+
+permissions:
+  contents: read
+
 jobs:
   ufmt_check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds `permissions: contents: read` to the SAM3/ufmt formatting check workflow.

The workflow only runs a Python formatter check on PRs. It does not write to the repository or interact with the GitHub API in ways that need write access. Restricting the GITHUB_TOKEN to read-only follows the principle of least privilege.