### PR TITLE
Fix gamma-zero focal loss NaN

### DIFF
--- a/sam3/model/decoder.py
+++ b/sam3/model/decoder.py
@@ -587,7 +587,7 @@ class TransformerDecoder(nn.Module):
 
                 # clamp to mitigate numerical issues
                 if self.clamp_presence_logits:
-                    intermediate_layer_presence_logits.clamp(
+                    intermediate_layer_presence_logits = intermediate_layer_presence_logits.clamp(
                         min=-self.clamp_presence_logit_max_val,
                         max=self.clamp_presence_logit_max_val,
                     )

--- a/sam3/train/loss/loss_fns.py
+++ b/sam3/train/loss/loss_fns.py
@@ -147,9 +147,10 @@ def sigmoid_focal_loss(
     Returns:
         Loss tensor
     """
-    if not (0 <= alpha <= 1) and triton:
+    use_triton = triton and gamma != 0
+    if not (0 <= alpha <= 1) and use_triton:
         raise RuntimeError(f"Alpha should be in [0,1], got {alpha}")
-    if triton:
+    if use_triton:
         if reduce and not loss_on_multimask:
             loss = triton_sigmoid_focal_loss_reduce(inputs, targets, alpha, gamma)
             return loss / (num_boxes * inputs.shape[1])


### PR DESCRIPTION
Fixes #575

### Summary

This PR fixes two related numerical issues around the SAM3 presence loss path:

- route `sigmoid_focal_loss(..., gamma=0)` away from the reduced Triton focal kernel and through the existing PyTorch fallback path
- make the intended presence-logit clamp effective by assigning the result of `clamp(...)`

For `gamma=0`, sigmoid focal loss is equivalent to alpha-weighted BCE. The reduced Triton backward currently computes `(1 - p_t) ** (gamma - 1)`, which becomes `0 ** -1 = inf` for saturated correct predictions, and later produces `0 * inf = NaN`.

### Verification

- `python -m py_compile sam3/train/loss/loss_fns.py sam3/model/decoder.py`
- CUDA smoke test with `sigmoid_focal_loss(x=[[18.0]], y=[[1.0]], alpha=0.5, gamma=0.0)` now returns a finite gradient (`[[0.0]]`).

I also verified this locally on a SAM3 fine-tuning run where the original issue first appeared as a NaN gradient in `SigmoidFocalLossReducedBackward`; after the fix, the epoch-6 canary reached the final dataloader step with finite loss and outputs.
