### PR TITLE
Fix hardcoded 'cuda' device in position_encoding.py to support CPU

### DIFF
--- a/sam3/model/position_encoding.py
+++ b/sam3/model/position_encoding.py
@@ -52,7 +52,7 @@ class PositionEmbeddingSine(nn.Module):
                 (precompute_resolution // 32, precompute_resolution // 32),
             ]
             for size in precompute_sizes:
-                tensors = torch.zeros((1, 1) + size, device="cuda")
+                tensors = torch.zeros((1, 1) + size, device="cuda" if torch.cuda.is_available() else "cpu")
                 self.forward(tensors)
                 # further clone and detach it in the cache (just to be safe)
                 self.cache[size] = self.cache[size].clone().detach()


### PR DESCRIPTION
## Description
This PR fixes an issue where the model fails to run in CPU-only environments because the tensor device was hardcoded to `"cuda"` in `sam3/model/position_encoding.py`. 

I have updated it to dynamically select `"cuda"` or `"cpu"` based on CUDA availability, ensuring cross-platform compatibility.

## Related Issue
https://github.com/facebookresearch/sam3/issues/587

## Changes Made
- Modified `sam3/model/position_encoding.py` to use `"cuda" if torch.cuda.is_available() else "cpu"` instead of the hardcoded `"cuda"` string.