### PR TITLE
Add einops to base dependencies (fixes #212)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "iopath>=0.1.10",
     "typing_extensions",
     "huggingface_hub",
+    "einops",
 ]
 
 [project.optional-dependencies]
@@ -61,7 +62,6 @@ notebooks = [
     "pycocotools",
     "decord",
     "opencv-python",
-    "einops",
     "scikit-image",
     "scikit-learn",
 ]


### PR DESCRIPTION
## Summary

  `einops` is imported at module-load time on the core model path but is only declared in
  the optional `notebooks` extra, so a base install (`pip install .` or
  `pip install git+https://github.com/facebookresearch/sam3.git`) crashes on `import sam3`.

  This moves `einops` into `[project].dependencies` so the package imports out of the box.

  Fixes #212.

  ### The import chain that triggers it

  `import sam3` → `sam3/__init__.py` → `model_builder` → `model/decoder` →
  `sam/transformer` → `sam/rope.py`, which does:

  ```python
  from einops import rearrange, repeat
  ```
  
  This is on the default inference path (RoPE), not behind any use_fa3 / notebook / fast-kernel guard, so every consumer needs `einops`.