### PR TITLE
Fix inference mode silently lost in example notebooks (#577)

### DIFF
--- a/examples/sam3_agent.ipynb
+++ b/examples/sam3_agent.ipynb
@@ -53,7 +53,7 @@
         "torch.autocast(\"cuda\", dtype=torch.bfloat16).__enter__()\n",
         "\n",
         "# inference mode for the whole notebook. Disable if you need gradients\n",
-        "torch.inference_mode().__enter__()"
+        "torch.set_grad_enabled(False)"
       ]
     },
     {

--- a/examples/sam3_image_batched_inference.ipynb
+++ b/examples/sam3_image_batched_inference.ipynb
@@ -81,7 +81,7 @@
     "torch.autocast(\"cuda\", dtype=torch.bfloat16).__enter__()\n",
     "\n",
     "# inference mode for the whole notebook. Disable if you need gradients\n",
-    "torch.inference_mode().__enter__()\n"
+    "torch.set_grad_enabled(False)\n"
    ]
   },
   {

--- a/examples/sam3_image_interactive.ipynb
+++ b/examples/sam3_image_interactive.ipynb
@@ -75,7 +75,7 @@
     "torch.autocast(\"cuda\", dtype=torch.bfloat16).__enter__()\n",
     "\n",
     "# inference mode for the whole notebook. Disable if you need gradients\n",
-    "torch.inference_mode().__enter__()"
+    "torch.set_grad_enabled(False)"
    ]
   },
   {


### PR DESCRIPTION
The notebooks enable inference mode via `torch.inference_mode().__enter__()`. Nothing keeps a reference to the returned guard object, so Python garbage-collects it immediately and its destructor restores grad-enabled state. The notebook then runs with grad enabled, and the fused `addmm_act` kernel raises `ValueError: Expected grad to be disabled.`

Use `torch.set_grad_enabled(False)`, which flips global state with no guard object to collect, so it persists for the rest of the notebook. Applied to all three affected notebooks (sam3_image_interactive, sam3_image_batched_inference, sam3_agent).

Fixes #577 