### PR TITLE
Fix _load_checkpoint for fine-tuned checkpoint layouts

### DIFF
--- a/sam3/model_builder.py
+++ b/sam3/model_builder.py
@@ -542,9 +542,19 @@ def _load_checkpoint(model, checkpoint_path):
         ckpt = torch.load(f, map_location="cpu", weights_only=True)
     if "model" in ckpt and isinstance(ckpt["model"], dict):
         ckpt = ckpt["model"]
+    # Checkpoints saved from a DDP-wrapped model (e.g. the training pipeline
+    # described in README_TRAIN.md) prefix every key with "module."
+    ckpt = {
+        (k[len("module.") :] if k.startswith("module.") else k): v
+        for k, v in ckpt.items()
+    }
     sam3_image_ckpt = {
         k.replace("detector.", ""): v for k, v in ckpt.items() if "detector" in k
     }
+    if not sam3_image_ckpt:
+        # Checkpoint saved directly from the image model: its keys have no
+        # "detector." prefix, so the filter above would drop all of them.
+        sam3_image_ckpt = ckpt
     if model.inst_interactive_predictor is not None:
         sam3_image_ckpt.update(
             {
@@ -553,11 +563,17 @@ def _load_checkpoint(model, checkpoint_path):
                 if "tracker" in k
             }
         )
-    missing_keys, _ = model.load_state_dict(sam3_image_ckpt, strict=False)
-    if len(missing_keys) > 0:
+    if not set(sam3_image_ckpt) & set(model.state_dict()):
+        raise ValueError(
+            f"no key in checkpoint {checkpoint_path} matches the model state dict; "
+            "loading it would leave the model randomly initialized. Sample "
+            f"checkpoint keys: {sorted(sam3_image_ckpt)[:5]}"
+        )
+    missing_keys, unexpected_keys = model.load_state_dict(sam3_image_ckpt, strict=False)
+    if len(missing_keys) > 0 or len(unexpected_keys) > 0:
         print(
             f"loaded {checkpoint_path} and found "
-            f"missing and/or unexpected keys:\n{missing_keys=}"
+            f"missing and/or unexpected keys:\n{missing_keys=}\n{unexpected_keys=}"
         )
 
 

--- a/test/test_model_builder.py
+++ b/test/test_model_builder.py
@@ -1,0 +1,89 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved
+
+"""Tests for _load_checkpoint handling of the various checkpoint key layouts."""
+
+import os
+import tempfile
+import unittest
+
+import torch
+
+from sam3.model_builder import _load_checkpoint
+
+
+class _DummyImageModel(torch.nn.Module):
+    """Minimal stand-in for the SAM3 image model."""
+
+    inst_interactive_predictor = None
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.backbone = torch.nn.Linear(4, 4, bias=False)
+        self.head = torch.nn.Linear(4, 2, bias=False)
+
+
+class TestLoadCheckpoint(unittest.TestCase):
+    def setUp(self) -> None:
+        torch.manual_seed(0)
+        self.model = _DummyImageModel()
+        self.reference = _DummyImageModel()
+        # Give the reference model distinct weights so we can tell whether
+        # loading actually happened.
+        with torch.no_grad():
+            for p in self.reference.parameters():
+                p.add_(1.0)
+        self._tmpdir = tempfile.TemporaryDirectory()
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+
+    def _save(self, ckpt: dict) -> str:
+        path = os.path.join(self._tmpdir.name, "ckpt.pt")
+        torch.save(ckpt, path)
+        return path
+
+    def _assert_loaded(self) -> None:
+        for (name, p), (_, p_ref) in zip(
+            self.model.named_parameters(), self.reference.named_parameters()
+        ):
+            self.assertTrue(torch.equal(p, p_ref), f"parameter {name} was not loaded")
+
+    def test_detector_prefixed_checkpoint(self) -> None:
+        """Official layout: keys prefixed with 'detector.'."""
+        ckpt = {f"detector.{k}": v for k, v in self.reference.state_dict().items()}
+        _load_checkpoint(self.model, self._save(ckpt))
+        self._assert_loaded()
+
+    def test_model_wrapped_checkpoint(self) -> None:
+        """Training layout: state dict nested under a 'model' key."""
+        ckpt = {
+            "model": {
+                f"detector.{k}": v for k, v in self.reference.state_dict().items()
+            }
+        }
+        _load_checkpoint(self.model, self._save(ckpt))
+        self._assert_loaded()
+
+    def test_ddp_module_prefixed_checkpoint(self) -> None:
+        """DDP training layout: keys prefixed with 'module.detector.'."""
+        ckpt = {
+            f"module.detector.{k}": v for k, v in self.reference.state_dict().items()
+        }
+        _load_checkpoint(self.model, self._save(ckpt))
+        self._assert_loaded()
+
+    def test_plain_image_model_checkpoint(self) -> None:
+        """Checkpoint saved directly from the image model (no 'detector.' prefix)."""
+        _load_checkpoint(self.model, self._save(dict(self.reference.state_dict())))
+        self._assert_loaded()
+
+    def test_mismatched_checkpoint_raises(self) -> None:
+        """A checkpoint with no matching key must raise instead of silently
+        leaving the model randomly initialized."""
+        ckpt = {"some.other.model.weight": torch.zeros(2, 2)}
+        with self.assertRaises(ValueError):
+            _load_checkpoint(self.model, self._save(ckpt))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #606

## What

Makes `build_sam3_image_model(checkpoint_path=...)` work with checkpoints produced by fine-tuning (per `README_TRAIN.md`), and makes its failure mode loud instead of silent:

- Strip a leading DDP `module.` prefix before filtering keys.
- If no `detector.*` key exists, fall back to using the checkpoint keys as-is (checkpoint saved directly from the image model).
- Raise a clear `ValueError` when no checkpoint key matches the model state dict, instead of silently returning a randomly-initialized model.
- Report `unexpected_keys` alongside `missing_keys` (previously discarded).

Official release checkpoints load exactly as before — the `detector.`-prefixed and `{"model": ...}`-wrapped layouts are covered by the new tests and their behavior is unchanged.

## Test plan

Added `test/test_model_builder.py` with 5 unit tests covering the checkpoint layouts (official `detector.` prefix, `{"model": ...}` wrapper, DDP `module.detector.` prefix, plain image-model keys, and fully mismatched keys → `ValueError`).

- On this branch: 5/5 pass.
- On `main`: the 3 tests covering the bugs fail; the 2 official-layout tests pass (backward compatibility).
- `ufmt check` passes on both files.

(Tests were run on macOS with the lazy-triton workaround from #482, since triton has no macOS wheels.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)