### PR TITLE
Fix training crash in addmm_act by falling back to unfused ops when grad is enabled

### DIFF
--- a/sam3/perflib/fused.py
+++ b/sam3/perflib/fused.py
@@ -9,7 +9,14 @@ addmm_act_op = torch.ops.aten._addmm_activation
 
 def addmm_act(activation, linear, mat1):
     if torch.is_grad_enabled():
-        raise ValueError("Expected grad to be disabled.")
+        # Training path: the fused kernel below is inference-only (detached
+        # weights, bf16 cast), so fall back to standard autograd-friendly ops.
+        y = linear(mat1)
+        if activation in [torch.nn.functional.relu, torch.nn.ReLU]:
+            return torch.nn.functional.relu(y)
+        if activation in [torch.nn.functional.gelu, torch.nn.GELU]:
+            return torch.nn.functional.gelu(y)
+        raise ValueError(f"Unexpected activation {activation}")
     self = linear.bias.detach()
     mat2 = linear.weight.detach()
     self = self.to(torch.bfloat16)


### PR DESCRIPTION
## Problem

Since the SAM 3.1 update, `vitdet.py::Mlp.forward()` unconditionally calls `perflib/fused.py::addmm_act()`, which is inference-only (it detaches weights and casts to bf16) and explicitly raises when gradients are enabled. As a result, any training or fine-tuning run on current `main` — including the documented Roboflow configs (`roboflow_v100_full_ft_100_images.yaml`) — crashes in the first vision-backbone forward pass with:

```
ValueError: Expected grad to be disabled.
```

This is the crash reported in #610 (closed with a "pin to the pre-3.1 commit" workaround) and related to the question in #509. The workaround forfeits the 3.1 improvements; this PR makes training work on current `main`.

## Fix

When `torch.is_grad_enabled()`, fall back to the mathematically equivalent standard ops (`linear` + `relu`/`gelu`), which support autograd. Inference is untouched — the fused fast path still runs whenever grads are disabled.

## Validation

With this patch, a full 20-epoch fine-tune of the Roboflow config (custom 200-image single-class COCO dataset, 1× L4, `--use-cluster 0 --num-gpus 1`) runs to completion: losses converge normally (composite 214 → 61; bbox L1 halved; GIoU −43%), and the resulting checkpoint improves held-out detection F1 from 0.394 (zero-shot) to 0.520 — confirming gradients flow correctly through the patched path. Inference before/after the patch is unchanged.

Happy to rework if you'd prefer gating at the module level (e.g. branching in `vitdet.Mlp.forward`) instead of inside `addmm_act`.